### PR TITLE
[RFC] Refactor Pointer enum into a protocol with a generic implementation

### DIFF
--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -123,11 +123,11 @@ public struct Commit: ObjectType {
 	/// The OID of the commit.
 	public let oid: OID
 
-	/// The OID of the commit's tree.
-	public let tree: OID
+	/// A pointer to the commit's tree.
+	public let tree: PointerOf<Tree>
 
-	/// The OIDs of the commit's parents.
-	public let parents: [OID]
+	/// Pointers to the commit's parents.
+	public let parents: [PointerOf<Commit>]
 
 	/// The author of the commit.
 	public let author: Signature
@@ -144,10 +144,10 @@ public struct Commit: ObjectType {
 		message = String.fromCString(git_commit_message(pointer))!
 		author = Signature(git_commit_author(pointer).memory)
 		committer = Signature(git_commit_committer(pointer).memory)
-		tree = OID(git_commit_tree_id(pointer).memory)
+		tree = PointerOf(OID(git_commit_tree_id(pointer).memory))
 
 		self.parents = map(0..<git_commit_parentcount(pointer)) {
-			return OID(git_commit_parent_id(pointer, $0).memory)
+			return PointerOf(OID(git_commit_parent_id(pointer, $0).memory))
 		}
 	}
 }


### PR DESCRIPTION
For consideration in #6.

Although there’s a bit of a typesplosion here, the benefits are pretty great:
1. Type safety in pointers (when possible)
2. An easy-to-use generic pointer (when the type cannot be determined at compile-time)
3. A clear replacement for `OID` properties that actually refer to a kind of _thing_

Thoughts?
