### PR TITLE
Remove Box from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "Carthage/Checkouts/Result"]
 	path = Carthage/Checkouts/Result
 	url = https://github.com/antitypical/Result.git
-[submodule "Carthage/Checkouts/Box"]
-	path = Carthage/Checkouts/Box
-	url = https://github.com/robrix/Box.git


### PR DESCRIPTION
During the upgrade to Swift 2.0 in `5c8a600` the dependency on the
library Box was removed, but the submodule wasn't fully.

This caused projects depending on SwiftGit2 to fail when Carthage was
recursively retrieving dependencies as it would find reference to Box
but no directory for it. The error I encountered was as below:

```
Parse error: expected submodule commit SHA in output of task (ls-tree -z ... Carthage/Checkouts/Box) but encountered:
```