### PR TITLE
Upgrade Quick to v0.9.1

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,5 +1,5 @@
 github "jspahrsummers/xcconfigs" >= 0.7.2
-github "Quick/Quick" "v0.8.0"
+github "Quick/Quick" "v0.9.1"
 github "Quick/Nimble" ~> 3.0.0
 github "modocache/Guanaco" "5031bf67297afbe61ac0f2fbf3e3e8400b3f8888"
 github "ZipArchive/ZipArchive" ~> 1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "modocache/Guanaco" "5031bf67297afbe61ac0f2fbf3e3e8400b3f8888"
 github "Quick/Nimble" "v3.0.0"
-github "Quick/Quick" "v0.8.0"
+github "Quick/Quick" "v0.9.1"
 github "antitypical/Result" "1.0.1"
 github "ZipArchive/ZipArchive" "v1.1"
 github "jspahrsummers/xcconfigs" "0.8.1"


### PR DESCRIPTION
This improves the quality of the test output, as noted by @modocache in
https://github.com/SwiftGit2/SwiftGit2/pull/52

A full diff of the changes to Quick can be found here:

https://github.com/Quick/Quick/compare/v0.8.0...v0.9.1