### PR TITLE
Fix EXC_BAD_ACCESS when progress updates

### DIFF
--- a/SwiftGit2/SwiftGit2.m
+++ b/SwiftGit2/SwiftGit2.m
@@ -29,7 +29,7 @@ git_checkout_options SG2CheckoutOptions(SG2CheckoutProgressBlock progress) {
 	
 	if (progress != nil) {
 		result.progress_cb = SG2CheckoutProgressCallback;
-		result.progress_payload = (__bridge void *)[progress copy];
+		result.progress_payload = (__bridge_retained void *)[progress copy];
 	}
 	
 	return result;

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -475,9 +475,23 @@ class RepositorySpec: QuickSpec {
 				let HEAD = repo.HEAD().value
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
-				
+
 				expect(repo.checkout(repo.localBranchWithName("master").value!, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
+			}
+
+			it("should call block on progress") {
+				let repo = Fixtures.simpleRepository
+				let oid = OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!
+				expect(repo.HEAD().value?.shortName).to(equal("master"))
+
+				expect(repo.checkout(oid, strategy: .None, progress: { (path, completedSteps, totalSteps) -> Void in
+					expect(completedSteps).to(beLessThanOrEqualTo(totalSteps))
+				})).to(haveSucceeded())
+
+				let HEAD = repo.HEAD().value
+				expect(HEAD?.longName).to(equal("HEAD"))
+				expect(HEAD?.oid).to(equal(oid))
 			}
 		}
 		


### PR DESCRIPTION
Previously when a block was passed into checkout() it would be copied
but then the memory would be freed as nothing had retained a reference
to the copy. This meant that when block() was called in
SG2CheckoutProgressCallback() it would crash due to an attempt to
execute a random chunk of memory that previously contained the block.

This code now retains the payload after copying it.