### PR TITLE
Remove the implementation detail leak, implemented in swift

### DIFF
--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -23,7 +23,7 @@ private func checkoutProgressCallback(path: UnsafePointer<Int8>, completed_steps
 			block = buffer.move()
 			buffer.dealloc(1)
 		}
-		block((path == nil ? nil : String(path)), completed_steps, total_steps);
+		block(String.fromCString(path), completed_steps, total_steps);
 	}
 }
 

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -9,7 +9,44 @@
 import Foundation
 import Result
 
-public typealias CheckoutProgressBlock = SG2CheckoutProgressBlock
+public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void
+
+/// Helper function used as the libgit2 progress callback in git_checkout_options.
+/// This is a function with a type signature of git_checkout_progress_cb.
+private func checkoutProgressCallback(path: UnsafePointer<Int8>, completed_steps: Int, total_steps: Int, payload: UnsafeMutablePointer<Void>) -> Void {
+	if (payload != nil) {
+		let buffer = UnsafeMutablePointer<CheckoutProgressBlock>(payload)
+		let block: CheckoutProgressBlock
+		if completed_steps < total_steps {
+			block = buffer.memory
+		} else {
+			block = buffer.move()
+			buffer.dealloc(1)
+		}
+		block((path == nil ? nil : String(path)), completed_steps, total_steps);
+	}
+}
+
+/// Helper function for initializing libgit2 got_checkout_options.
+///
+/// :param: progress A block that's called with the progress of the checkout.
+/// :returns: Returns a git_checkout_options struct with the progress members set.
+private func checkoutOptions(progress: CheckoutProgressBlock? = nil) -> git_checkout_options {
+	// Do this because GIT_CHECKOUT_OPTIONS_INIT is unavailable in swift
+	let pointer = UnsafeMutablePointer<git_checkout_options>.alloc(1)
+	git_checkout_init_options(pointer, UInt32(GIT_CHECKOUT_OPTIONS_VERSION))
+	var options = pointer.move()
+	pointer.dealloc(1)
+
+	if progress != nil {
+		options.progress_cb = checkoutProgressCallback
+		let blockPointer = UnsafeMutablePointer<CheckoutProgressBlock>.alloc(1)
+		blockPointer.initialize(progress!)
+		options.progress_payload = UnsafeMutablePointer<Void>(blockPointer)
+	}
+
+	return options
+}
 
 /// A git repository.
 final public class Repository {
@@ -359,7 +396,7 @@ final public class Repository {
 	/// :param: progress A block that's called with the progress of the checkout.
 	/// :returns: Returns a result with void or the error that occurred.
 	public func checkout(strategy strategy: CheckoutStrategy, progress: CheckoutProgressBlock? = nil) -> Result<(), NSError> {
-		var options = SG2CheckoutOptions(progress)
+		var options = checkoutOptions(progress)
 		options.checkout_strategy = strategy.git_checkout_strategy.rawValue
 		
 		let result = git_checkout_head(self.pointer, &options)

--- a/SwiftGit2/SwiftGit2.h
+++ b/SwiftGit2/SwiftGit2.h
@@ -15,11 +15,3 @@ FOUNDATION_EXPORT double SwiftGit2VersionNumber;
 FOUNDATION_EXPORT const unsigned char SwiftGit2VersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <SwiftGit2/PublicHeader.h>
-
-#import "git2.h"
-
-typedef void (^SG2CheckoutProgressBlock)(NSString * __nullable, NSUInteger, NSUInteger);
-
-/// A C function for working with Libgit2. This shouldn't be called directly. It's an
-/// implementation detail that, unfortunately, leaks through to the public headers.
-extern git_checkout_options SG2CheckoutOptions(SG2CheckoutProgressBlock __nullable progress);

--- a/SwiftGit2/SwiftGit2.m
+++ b/SwiftGit2/SwiftGit2.m
@@ -7,30 +7,9 @@
 //
 
 #import "SwiftGit2.h"
-
+#import "git2.h"
 
 __attribute__((constructor))
 static void SwiftGit2Init(void) {
 	git_libgit2_init();
-}
-
-static void SG2CheckoutProgressCallback(const char *path, size_t completed_steps, size_t total_steps, void *payload) {
-	if (payload == NULL) return;
-	
-	SG2CheckoutProgressBlock block = (__bridge SG2CheckoutProgressBlock)payload;
-	block((path == nil ? nil : @(path)), completed_steps, total_steps);
-}
-
-git_checkout_options SG2CheckoutOptions(SG2CheckoutProgressBlock progress) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-	git_checkout_options result = GIT_CHECKOUT_OPTIONS_INIT;
-#pragma clang diagnostic pop
-	
-	if (progress != nil) {
-		result.progress_cb = SG2CheckoutProgressCallback;
-		result.progress_payload = (__bridge_retained void *)[progress copy];
-	}
-	
-	return result;
 }


### PR DESCRIPTION
Hello thank you for this great work!

This is my attempt at move "leaky details" in the public header to Swift.
My motivations are writing a pure swift package via Swift Package Manager.
You will also notice that the git2.h header no longer needs to be public either.

I also have a followup the last .m item (the constructor), to a central class, calling git_libgit2_init on init and shutdown on deinit, like this: https://github.com/drkibitz/swift-Git2/blob/master/Sources/Git2/Git2.swift