### PR TITLE
Swift API design guidelines

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,6 @@ disabled_rules:
   - function_body_length
   - line_length
   - type_body_length
-  - variable_name
 
 opt_in_rules:
   - closure_spacing

--- a/SwiftGit2/CheckoutStrategy.swift
+++ b/SwiftGit2/CheckoutStrategy.swift
@@ -38,7 +38,7 @@ public struct CheckoutStrategy: OptionSet {
 		return value
 	}
 	
-	public var git_checkout_strategy: git_checkout_strategy_t {
+	public var gitCheckoutStrategy: git_checkout_strategy_t {
 		return git_checkout_strategy_t(UInt32(self.value))
 	}
 	

--- a/SwiftGit2/Errors.swift
+++ b/SwiftGit2/Errors.swift
@@ -3,27 +3,29 @@ import libgit2
 
 public let libGit2ErrorDomain = "org.libgit2.libgit2"
 
-/// Returns an NSError with an error domain and message for libgit2 errors.
-///
-/// :param: errorCode An error code returned by a libgit2 function.
-/// :param: libGit2PointOfFailure The name of the libgit2 function that produced the
-///         error code.
-/// :returns: An NSError with a libgit2 error domain, code, and message.
-internal func libGit2Error(_ errorCode: Int32, libGit2PointOfFailure: String? = nil) -> NSError {
-	let code = Int(errorCode)
-	var userInfo: [String: String] = [:]
+internal extension NSError {
+	/// Returns an NSError with an error domain and message for libgit2 errors.
+	///
+	/// :param: errorCode An error code returned by a libgit2 function.
+	/// :param: libGit2PointOfFailure The name of the libgit2 function that produced the
+	///         error code.
+	/// :returns: An NSError with a libgit2 error domain, code, and message.
+	internal convenience init(gitError errorCode: Int32, pointOfFailure: String? = nil) {
+		let code = Int(errorCode)
+		var userInfo: [String: String] = [:]
 
-	if let message = errorMessage(errorCode) {
-		userInfo[NSLocalizedDescriptionKey] = message
-	} else {
-		userInfo[NSLocalizedDescriptionKey] = "Unknown libgit2 error."
+		if let message = errorMessage(errorCode) {
+			userInfo[NSLocalizedDescriptionKey] = message
+		} else {
+			userInfo[NSLocalizedDescriptionKey] = "Unknown libgit2 error."
+		}
+
+		if let pointOfFailure = pointOfFailure {
+			userInfo[NSLocalizedFailureReasonErrorKey] = "\(pointOfFailure) failed."
+		}
+
+		self.init(domain: libGit2ErrorDomain, code: code, userInfo: userInfo)
 	}
-
-	if let pointOfFailure = libGit2PointOfFailure {
-		userInfo[NSLocalizedFailureReasonErrorKey] = "\(pointOfFailure) failed."
-	}
-
-	return NSError(domain: libGit2ErrorDomain, code: code, userInfo: userInfo)
 }
 
 /// Returns the libgit2 error message for the given error code.

--- a/SwiftGit2/Libgit2.swift
+++ b/SwiftGit2/Libgit2.swift
@@ -13,14 +13,14 @@ func == (lhs: git_otype, rhs: git_otype) -> Bool {
 }
 
 extension git_strarray {
-	func filter(f: (String) -> Bool) -> [String] {
-		return map { $0 }.filter(f)
+	func filter(_ isIncluded: (String) -> Bool) -> [String] {
+		return map { $0 }.filter(isIncluded)
 	}
 	
-	func map<T>(f: (String) -> T) -> [T] {
+	func map<T>(_ transform: (String) -> T) -> [T] {
 		return (0..<self.count).map {
 			let string = String(validatingUTF8: self.strings[$0]!)!
-			return f(string)
+			return transform(string)
 		}
 	}
 }

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -185,7 +185,7 @@ final public class Repository {
 	///
 	/// Returns the result of calling `transform` or an error if the object
 	/// cannot be loaded.
-	private func withGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
+	private func withGitObject<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
 		var pointer: OpaquePointer? = nil
 		var oid = oid.oid
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
@@ -199,8 +199,8 @@ final public class Repository {
 		return value
 	}
 	
-	private func withGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
-		return withGitObject(withIdentity: oid, type: type) { Result.success(transform($0)) }
+	private func withGitObject<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
+		return withGitObject(oid, type: type) { Result.success(transform($0)) }
 	}
 	
 	/// Loads the object with the given OID.
@@ -208,8 +208,8 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns a `Blob`, `Commit`, `Tag`, or `Tree` if one exists, or an error.
-	public func object(withIdentity oid: OID) -> Result<ObjectType, NSError> {
-		return withGitObject(withIdentity: oid, type: GIT_OBJ_ANY) { object in
+	public func object(_ oid: OID) -> Result<ObjectType, NSError> {
+		return withGitObject(oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
 			if type == Blob.type {
 				return Result.success(Blob(object))
@@ -237,8 +237,8 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns the blob if it exists, or an error.
-	public func blob(withIdentity oid: OID) -> Result<Blob, NSError> {
-		return withGitObject(withIdentity: oid, type: GIT_OBJ_BLOB) { Blob($0) }
+	public func blob(_ oid: OID) -> Result<Blob, NSError> {
+		return withGitObject(oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
 	
 	/// Loads the commit with the given OID.
@@ -246,8 +246,8 @@ final public class Repository {
 	/// oid - The OID of the commit to look up.
 	///
 	/// Returns the commit if it exists, or an error.
-	public func commit(withIdentity oid: OID) -> Result<Commit, NSError> {
-		return withGitObject(withIdentity: oid, type: GIT_OBJ_COMMIT) { Commit($0) }
+	public func commit(_ oid: OID) -> Result<Commit, NSError> {
+		return withGitObject(oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
 	
 	/// Loads the tag with the given OID.
@@ -255,8 +255,8 @@ final public class Repository {
 	/// oid - The OID of the tag to look up.
 	///
 	/// Returns the tag if it exists, or an error.
-	public func tag(withIdentity oid: OID) -> Result<Tag, NSError> {
-		return withGitObject(withIdentity: oid, type: GIT_OBJ_TAG) { Tag($0) }
+	public func tag(_ oid: OID) -> Result<Tag, NSError> {
+		return withGitObject(oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
 	
 	/// Loads the tree with the given OID.
@@ -264,8 +264,8 @@ final public class Repository {
 	/// oid - The OID of the tree to look up.
 	///
 	/// Returns the tree if it exists, or an error.
-	public func tree(withIdentity oid: OID) -> Result<Tree, NSError> {
-		return withGitObject(withIdentity: oid, type: GIT_OBJ_TREE) { Tree($0) }
+	public func tree(_ oid: OID) -> Result<Tree, NSError> {
+		return withGitObject(oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.
@@ -274,7 +274,7 @@ final public class Repository {
 	///
 	/// Returns the object if it exists, or an error.
 	public func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError> {
-		return withGitObject(withIdentity: pointer.oid, type: pointer.type) { T($0) }
+		return withGitObject(pointer.oid, type: pointer.type) { T($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.
@@ -285,13 +285,13 @@ final public class Repository {
 	public func object(from pointer: Pointer) -> Result<ObjectType, NSError> {
 		switch pointer {
 		case let .Blob(oid):
-			return blob(withIdentity: oid).map { $0 as ObjectType }
+			return blob(oid).map { $0 as ObjectType }
 		case let .Commit(oid):
-			return commit(withIdentity: oid).map { $0 as ObjectType }
+			return commit(oid).map { $0 as ObjectType }
 		case let .Tag(oid):
-			return tag(withIdentity: oid).map { $0 as ObjectType }
+			return tag(oid).map { $0 as ObjectType }
 		case let .Tree(oid):
-			return tree(withIdentity: oid).map { $0 as ObjectType }
+			return tree(oid).map { $0 as ObjectType }
 		}
 	}
 	

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -110,7 +110,7 @@ final public class Repository {
 		}
 		
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_repository_open"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_repository_open"))
 		}
 		
 		let repository = Repository(pointer!)
@@ -142,7 +142,7 @@ final public class Repository {
 			}
 
 			if result != GIT_OK.rawValue {
-				return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_clone"))
+				return Result.failure(NSError(gitError: result, pointOfFailure: "git_clone"))
 			}
 
 			let repository = Repository(pointer!)
@@ -191,7 +191,7 @@ final public class Repository {
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
 		
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_object_lookup"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_object_lookup"))
 		}
 		
 		let value = transform(pointer!)
@@ -306,7 +306,7 @@ final public class Repository {
 		
 		if result != GIT_OK.rawValue {
 			pointer.deallocate(capacity: 1)
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_remote_list"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_remote_list"))
 		}
 		
 		let strarray = pointer.pointee
@@ -333,7 +333,7 @@ final public class Repository {
 		let result = git_remote_lookup(&pointer, self.pointer, name)
 		
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_remote_lookup"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_remote_lookup"))
 		}
 		
 		let value = Remote(pointer!)
@@ -350,7 +350,7 @@ final public class Repository {
 		
 		if result != GIT_OK.rawValue {
 			pointer.deallocate(capacity: 1)
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_reference_list"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_reference_list"))
 		}
 		
 		let strarray = pointer.pointee
@@ -381,7 +381,7 @@ final public class Repository {
 		let result = git_reference_lookup(&pointer, self.pointer, name)
 		
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_reference_lookup"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_reference_lookup"))
 		}
 		
 		let value = referenceWithLibGit2Reference(pointer!)
@@ -437,7 +437,7 @@ final public class Repository {
 		var pointer: OpaquePointer? = nil
 		let result = git_repository_head(&pointer, self.pointer)
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_repository_head"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_repository_head"))
 		}
 		let value = referenceWithLibGit2Reference(pointer!)
 		git_reference_free(pointer)
@@ -452,7 +452,7 @@ final public class Repository {
 		var oid = oid.oid
 		let result = git_repository_set_head_detached(self.pointer, &oid)
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_repository_set_head"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_repository_set_head"))
 		}
 		return Result.success()
 	}
@@ -464,7 +464,7 @@ final public class Repository {
 	public func setHEAD(_ reference: ReferenceType) -> Result<(), NSError> {
 		let result = git_repository_set_head(self.pointer, reference.longName)
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_repository_set_head"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_repository_set_head"))
 		}
 		return Result.success()
 	}
@@ -479,7 +479,7 @@ final public class Repository {
 		
 		let result = git_checkout_head(self.pointer, &options)
 		if result != GIT_OK.rawValue {
-			return Result.failure(libGit2Error(result, libGit2PointOfFailure: "git_checkout_head"))
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_checkout_head"))
 		}
 		
 		return Result.success()

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -103,7 +103,11 @@ final public class Repository {
 	/// URL - The URL of the repository.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
+	@available(*, unavailable, renamed: "at(_:)")
 	class public func atURL(_ url: URL) -> Result<Repository, NSError> {
+		fatalError()
+	}
+	class public func at(_ url: URL) -> Result<Repository, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = url.withUnsafeFileSystemRepresentation {
 			git_repository_open(&pointer, $0)
@@ -128,7 +132,12 @@ final public class Repository {
 	/// checkoutProgress - A block that's called with the progress of the checkout.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
+	@available(*, unavailable, renamed: "clone(from:to:localClone:bare:credentials:checkoutStrategy:checkoutProgress:)")
 	class public func cloneFromURL(_ remoteURL: URL, toURL: URL, localClone: Bool = false, bare: Bool = false,
+		credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe, checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
+		fatalError()
+	}
+	class public func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
 		credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe, checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
 			var options = cloneOptions(
 				bare: bare, localClone: localClone,
@@ -137,8 +146,8 @@ final public class Repository {
 
 			var pointer: OpaquePointer? = nil
 			let remoteURLString = (remoteURL as NSURL).isFileReferenceURL() ? remoteURL.path : remoteURL.absoluteString
-			let result = toURL.withUnsafeFileSystemRepresentation {
-				git_clone(&pointer, remoteURLString, $0, &options)
+			let result = localURL.withUnsafeFileSystemRepresentation { localPath in
+				git_clone(&pointer, remoteURLString, localPath, &options)
 			}
 
 			if result != GIT_OK.rawValue {
@@ -185,7 +194,7 @@ final public class Repository {
 	///
 	/// Returns the result of calling `transform` or an error if the object
 	/// cannot be loaded.
-	func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
+	private func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
 		var pointer: OpaquePointer? = nil
 		var oid = oid.oid
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
@@ -199,7 +208,7 @@ final public class Repository {
 		return value
 	}
 	
-	func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
+	private func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
 		return withLibgit2Object(oid, type: type) { Result.success(transform($0)) }
 	}
 	
@@ -208,7 +217,11 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns a `Blob`, `Commit`, `Tag`, or `Tree` if one exists, or an error.
+	@available(*, unavailable, renamed: "object(with:)")
 	public func objectWithOID(_ oid: OID) -> Result<ObjectType, NSError> {
+		fatalError()
+	}
+	public func object(with oid: OID) -> Result<ObjectType, NSError> {
 		return withLibgit2Object(oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
 			if type == Blob.type {
@@ -237,7 +250,11 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns the blob if it exists, or an error.
+	@available(*, unavailable, renamed: "blob(with:)")
 	public func blobWithOID(_ oid: OID) -> Result<Blob, NSError> {
+		fatalError()
+	}
+	public func blob(with oid: OID) -> Result<Blob, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
 	
@@ -246,7 +263,11 @@ final public class Repository {
 	/// oid - The OID of the commit to look up.
 	///
 	/// Returns the commit if it exists, or an error.
+	@available(*, unavailable, renamed: "commit(with:)")
 	public func commitWithOID(_ oid: OID) -> Result<Commit, NSError> {
+		fatalError()
+	}
+	public func commit(with oid: OID) -> Result<Commit, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
 	
@@ -255,7 +276,11 @@ final public class Repository {
 	/// oid - The OID of the tag to look up.
 	///
 	/// Returns the tag if it exists, or an error.
+	@available(*, unavailable, renamed: "tag(with:)")
 	public func tagWithOID(_ oid: OID) -> Result<Tag, NSError> {
+		fatalError()
+	}
+	public func tag(with oid: OID) -> Result<Tag, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
 	
@@ -264,7 +289,11 @@ final public class Repository {
 	/// oid - The OID of the tree to look up.
 	///
 	/// Returns the tree if it exists, or an error.
+	@available(*, unavailable, renamed: "tree(with:)")
 	public func treeWithOID(_ oid: OID) -> Result<Tree, NSError> {
+		fatalError()
+	}
+	public func tree(with oid: OID) -> Result<Tree, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
 	
@@ -273,7 +302,11 @@ final public class Repository {
 	/// pointer - A pointer to an object.
 	///
 	/// Returns the object if it exists, or an error.
+	@available(*, unavailable, renamed: "object(from:)")
 	public func objectFromPointer<T>(_ pointer: PointerTo<T>) -> Result<T, NSError> {
+		fatalError()
+	}
+	public func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError> {
 		return self.withLibgit2Object(pointer.oid, type: pointer.type) { T($0) }
 	}
 	
@@ -282,16 +315,20 @@ final public class Repository {
 	/// pointer - A pointer to an object.
 	///
 	/// Returns the object if it exists, or an error.
+	@available(*, unavailable, renamed: "object(from:)")
 	public func objectFromPointer(_ pointer: Pointer) -> Result<ObjectType, NSError> {
+		fatalError()
+	}
+	public func object(from pointer: Pointer) -> Result<ObjectType, NSError> {
 		switch pointer {
 		case let .Blob(oid):
-			return blobWithOID(oid).map { $0 as ObjectType }
+			return blob(with: oid).map { $0 as ObjectType }
 		case let .Commit(oid):
-			return commitWithOID(oid).map { $0 as ObjectType }
+			return commit(with: oid).map { $0 as ObjectType }
 		case let .Tag(oid):
-			return tagWithOID(oid).map { $0 as ObjectType }
+			return tag(with: oid).map { $0 as ObjectType }
 		case let .Tree(oid):
-			return treeWithOID(oid).map { $0 as ObjectType }
+			return tree(with: oid).map { $0 as ObjectType }
 		}
 	}
 	
@@ -311,7 +348,7 @@ final public class Repository {
 		
 		let strarray = pointer.pointee
 		let remotes: [Result<Remote, NSError>] = strarray.map {
-			return self.remoteWithName($0)
+			return self.remote(withName: $0)
 		}
 		git_strarray_free(pointer)
 		pointer.deallocate(capacity: 1)
@@ -328,7 +365,11 @@ final public class Repository {
 	/// name - The name of the remote.
 	///
 	/// Returns the remote if it exists, or an error.
+	@available(*, unavailable, renamed: "remote(withName:)")
 	public func remoteWithName(_ name: String) -> Result<Remote, NSError> {
+		fatalError()
+	}
+	public func remote(withName name: String) -> Result<Remote, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_remote_lookup(&pointer, self.pointer, name)
 		
@@ -344,7 +385,11 @@ final public class Repository {
 	// MARK: - Reference Lookups
 	
 	/// Load all the references with the given prefix (e.g. "refs/heads/")
+	@available(*, unavailable, renamed: "references(withPrefix:)")
 	public func referencesWithPrefix(_ prefix: String) -> Result<[ReferenceType], NSError> {
+		fatalError()
+	}
+	public func references(withPrefix prefix: String) -> Result<[ReferenceType], NSError> {
 		let pointer = UnsafeMutablePointer<git_strarray>.allocate(capacity: 1)
 		let result = git_reference_list(pointer, self.pointer)
 		
@@ -359,7 +404,7 @@ final public class Repository {
 				$0.hasPrefix(prefix)
 			}
 			.map {
-				self.referenceWithName($0)
+				self.reference(withName: $0)
 			}
 		git_strarray_free(pointer)
 		pointer.deallocate(capacity: 1)
@@ -376,7 +421,11 @@ final public class Repository {
 	/// If the reference is a branch, a `Branch` will be returned. If the
 	/// reference is a tag, a `TagReference` will be returned. Otherwise, a
 	/// `Reference` will be returned.
+	@available(*, unavailable, renamed: "reference(withName:)")
 	public func referenceWithName(_ name: String) -> Result<ReferenceType, NSError> {
+		fatalError()
+	}
+	public func reference(withName name: String) -> Result<ReferenceType, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_reference_lookup(&pointer, self.pointer, name)
 		
@@ -391,7 +440,7 @@ final public class Repository {
 	
 	/// Load and return a list of all local branches.
 	public func localBranches() -> Result<[Branch], NSError> {
-		return referencesWithPrefix("refs/heads/")
+		return references(withPrefix: "refs/heads/")
 			.map { (refs: [ReferenceType]) in
 				return refs.map { $0 as! Branch }
 			}
@@ -399,33 +448,45 @@ final public class Repository {
 	
 	/// Load and return a list of all remote branches.
 	public func remoteBranches() -> Result<[Branch], NSError> {
-		return referencesWithPrefix("refs/remotes/")
+		return references(withPrefix: "refs/remotes/")
 			.map { (refs: [ReferenceType]) in
 				return refs.map { $0 as! Branch }
 			}
 	}
 	
 	/// Load the local branch with the given name (e.g., "master").
+	@available(*, unavailable, renamed: "localBranch(withName:)")
 	public func localBranchWithName(_ name: String) -> Result<Branch, NSError> {
-		return referenceWithName("refs/heads/" + name).map { $0 as! Branch }
+		fatalError()
+	}
+	public func localBranch(withName name: String) -> Result<Branch, NSError> {
+		return reference(withName: "refs/heads/" + name).map { $0 as! Branch }
 	}
 	
 	/// Load the remote branch with the given name (e.g., "origin/master").
+	@available(*, unavailable, renamed: "remoteBranch(withName:)")
 	public func remoteBranchWithName(_ name: String) -> Result<Branch, NSError> {
-		return referenceWithName("refs/remotes/" + name).map { $0 as! Branch }
+		fatalError()
+	}
+	public func remoteBranch(withName name: String) -> Result<Branch, NSError> {
+		return reference(withName: "refs/remotes/" + name).map { $0 as! Branch }
 	}
 	
 	/// Load and return a list of all the `TagReference`s.
 	public func allTags() -> Result<[TagReference], NSError> {
-		return referencesWithPrefix("refs/tags/")
+		return references(withPrefix: "refs/tags/")
 			.map { (refs: [ReferenceType]) in
 				return refs.map { $0 as! TagReference }
 			}
 	}
 	
 	/// Load the tag with the given name (e.g., "tag-2").
+	@available(*, unavailable, renamed: "tag(withName:)")
 	public func tagWithName(_ name: String) -> Result<TagReference, NSError> {
-		return referenceWithName("refs/tags/" + name).map { $0 as! TagReference }
+		fatalError()
+	}
+	public func tag(withName name: String) -> Result<TagReference, NSError> {
+		return reference(withName: "refs/tags/" + name).map { $0 as! TagReference }
 	}
 	
 	// MARK: - Working Directory

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -194,7 +194,7 @@ final public class Repository {
 	///
 	/// Returns the result of calling `transform` or an error if the object
 	/// cannot be loaded.
-	private func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
+	private func mapGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
 		var pointer: OpaquePointer? = nil
 		var oid = oid.oid
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
@@ -208,8 +208,8 @@ final public class Repository {
 		return value
 	}
 	
-	private func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
-		return withLibgit2Object(oid, type: type) { Result.success(transform($0)) }
+	private func mapGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
+		return mapGitObject(withIdentity: oid, type: type) { Result.success(transform($0)) }
 	}
 	
 	/// Loads the object with the given OID.
@@ -222,7 +222,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func object(withIdentity oid: OID) -> Result<ObjectType, NSError> {
-		return withLibgit2Object(oid, type: GIT_OBJ_ANY) { object in
+		return mapGitObject(withIdentity: oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
 			if type == Blob.type {
 				return Result.success(Blob(object))
@@ -255,7 +255,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func blob(withIdentity oid: OID) -> Result<Blob, NSError> {
-		return self.withLibgit2Object(oid, type: GIT_OBJ_BLOB) { Blob($0) }
+		return mapGitObject(withIdentity: oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
 	
 	/// Loads the commit with the given OID.
@@ -268,7 +268,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func commit(withIdentity oid: OID) -> Result<Commit, NSError> {
-		return self.withLibgit2Object(oid, type: GIT_OBJ_COMMIT) { Commit($0) }
+		return mapGitObject(withIdentity: oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
 	
 	/// Loads the tag with the given OID.
@@ -281,7 +281,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func tag(withIdentity oid: OID) -> Result<Tag, NSError> {
-		return self.withLibgit2Object(oid, type: GIT_OBJ_TAG) { Tag($0) }
+		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
 	
 	/// Loads the tree with the given OID.
@@ -294,7 +294,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func tree(withIdentity oid: OID) -> Result<Tree, NSError> {
-		return self.withLibgit2Object(oid, type: GIT_OBJ_TREE) { Tree($0) }
+		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.
@@ -307,7 +307,7 @@ final public class Repository {
 		fatalError()
 	}
 	public func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError> {
-		return self.withLibgit2Object(pointer.oid, type: pointer.type) { T($0) }
+		return mapGitObject(withIdentity: pointer.oid, type: pointer.type) { T($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -14,17 +14,17 @@ public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void
 
 /// Helper function used as the libgit2 progress callback in git_checkout_options.
 /// This is a function with a type signature of git_checkout_progress_cb.
-private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completed_steps: Int, total_steps: Int, payload: UnsafeMutableRawPointer?) -> Void {
+private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps: Int, totalSteps: Int, payload: UnsafeMutableRawPointer?) -> Void {
 	if let payload = payload {
 		let buffer = payload.assumingMemoryBound(to: CheckoutProgressBlock.self)
 		let block: CheckoutProgressBlock
-		if completed_steps < total_steps {
+		if completedSteps < totalSteps {
 			block = buffer.pointee
 		} else {
 			block = buffer.move()
 			buffer.deallocate(capacity: 1)
 		}
-		block(path.flatMap(String.init(validatingUTF8:)), completed_steps, total_steps)
+		block(path.flatMap(String.init(validatingUTF8:)), completedSteps, totalSteps)
 	}
 }
 
@@ -40,7 +40,7 @@ private func checkoutOptions(strategy: CheckoutStrategy, progress: CheckoutProgr
 	var options = pointer.move()
 	pointer.deallocate(capacity: 1)
 
-	options.checkout_strategy = strategy.git_checkout_strategy.rawValue
+	options.checkout_strategy = strategy.gitCheckoutStrategy.rawValue
 
 	if progress != nil {
 		options.progress_cb = checkoutProgressCallback

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -185,7 +185,7 @@ final public class Repository {
 	///
 	/// Returns the result of calling `transform` or an error if the object
 	/// cannot be loaded.
-	private func mapGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
+	private func withGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
 		var pointer: OpaquePointer? = nil
 		var oid = oid.oid
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
@@ -199,8 +199,8 @@ final public class Repository {
 		return value
 	}
 	
-	private func mapGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
-		return mapGitObject(withIdentity: oid, type: type) { Result.success(transform($0)) }
+	private func withGitObject<T>(withIdentity oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError> {
+		return withGitObject(withIdentity: oid, type: type) { Result.success(transform($0)) }
 	}
 	
 	/// Loads the object with the given OID.
@@ -209,7 +209,7 @@ final public class Repository {
 	///
 	/// Returns a `Blob`, `Commit`, `Tag`, or `Tree` if one exists, or an error.
 	public func object(withIdentity oid: OID) -> Result<ObjectType, NSError> {
-		return mapGitObject(withIdentity: oid, type: GIT_OBJ_ANY) { object in
+		return withGitObject(withIdentity: oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
 			if type == Blob.type {
 				return Result.success(Blob(object))
@@ -238,7 +238,7 @@ final public class Repository {
 	///
 	/// Returns the blob if it exists, or an error.
 	public func blob(withIdentity oid: OID) -> Result<Blob, NSError> {
-		return mapGitObject(withIdentity: oid, type: GIT_OBJ_BLOB) { Blob($0) }
+		return withGitObject(withIdentity: oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
 	
 	/// Loads the commit with the given OID.
@@ -247,7 +247,7 @@ final public class Repository {
 	///
 	/// Returns the commit if it exists, or an error.
 	public func commit(withIdentity oid: OID) -> Result<Commit, NSError> {
-		return mapGitObject(withIdentity: oid, type: GIT_OBJ_COMMIT) { Commit($0) }
+		return withGitObject(withIdentity: oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
 	
 	/// Loads the tag with the given OID.
@@ -256,7 +256,7 @@ final public class Repository {
 	///
 	/// Returns the tag if it exists, or an error.
 	public func tag(withIdentity oid: OID) -> Result<Tag, NSError> {
-		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TAG) { Tag($0) }
+		return withGitObject(withIdentity: oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
 	
 	/// Loads the tree with the given OID.
@@ -265,7 +265,7 @@ final public class Repository {
 	///
 	/// Returns the tree if it exists, or an error.
 	public func tree(withIdentity oid: OID) -> Result<Tree, NSError> {
-		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TREE) { Tree($0) }
+		return withGitObject(withIdentity: oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.
@@ -274,7 +274,7 @@ final public class Repository {
 	///
 	/// Returns the object if it exists, or an error.
 	public func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError> {
-		return mapGitObject(withIdentity: pointer.oid, type: pointer.type) { T($0) }
+		return withGitObject(withIdentity: pointer.oid, type: pointer.type) { T($0) }
 	}
 	
 	/// Loads the referenced object from the pointer.

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -311,7 +311,7 @@ final public class Repository {
 		
 		let strarray = pointer.pointee
 		let remotes: [Result<Remote, NSError>] = strarray.map {
-			return self.remote(withName: $0)
+			return self.remote(named: $0)
 		}
 		git_strarray_free(pointer)
 		pointer.deallocate(capacity: 1)
@@ -328,7 +328,7 @@ final public class Repository {
 	/// name - The name of the remote.
 	///
 	/// Returns the remote if it exists, or an error.
-	public func remote(withName name: String) -> Result<Remote, NSError> {
+	public func remote(named name: String) -> Result<Remote, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_remote_lookup(&pointer, self.pointer, name)
 		
@@ -359,7 +359,7 @@ final public class Repository {
 				$0.hasPrefix(prefix)
 			}
 			.map {
-				self.reference(withName: $0)
+				self.reference(named: $0)
 			}
 		git_strarray_free(pointer)
 		pointer.deallocate(capacity: 1)
@@ -376,7 +376,7 @@ final public class Repository {
 	/// If the reference is a branch, a `Branch` will be returned. If the
 	/// reference is a tag, a `TagReference` will be returned. Otherwise, a
 	/// `Reference` will be returned.
-	public func reference(withName name: String) -> Result<ReferenceType, NSError> {
+	public func reference(named name: String) -> Result<ReferenceType, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_reference_lookup(&pointer, self.pointer, name)
 		
@@ -406,13 +406,13 @@ final public class Repository {
 	}
 	
 	/// Load the local branch with the given name (e.g., "master").
-	public func localBranch(withName name: String) -> Result<Branch, NSError> {
-		return reference(withName: "refs/heads/" + name).map { $0 as! Branch }
+	public func localBranch(named name: String) -> Result<Branch, NSError> {
+		return reference(named: "refs/heads/" + name).map { $0 as! Branch }
 	}
 	
 	/// Load the remote branch with the given name (e.g., "origin/master").
-	public func remoteBranch(withName name: String) -> Result<Branch, NSError> {
-		return reference(withName: "refs/remotes/" + name).map { $0 as! Branch }
+	public func remoteBranch(named name: String) -> Result<Branch, NSError> {
+		return reference(named: "refs/remotes/" + name).map { $0 as! Branch }
 	}
 	
 	/// Load and return a list of all the `TagReference`s.
@@ -424,8 +424,8 @@ final public class Repository {
 	}
 	
 	/// Load the tag with the given name (e.g., "tag-2").
-	public func tag(withName name: String) -> Result<TagReference, NSError> {
-		return reference(withName: "refs/tags/" + name).map { $0 as! TagReference }
+	public func tag(named name: String) -> Result<TagReference, NSError> {
+		return reference(named: "refs/tags/" + name).map { $0 as! TagReference }
 	}
 	
 	// MARK: - Working Directory

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -103,10 +103,6 @@ final public class Repository {
 	/// URL - The URL of the repository.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
-	@available(*, unavailable, renamed: "at(_:)")
-	class public func atURL(_ url: URL) -> Result<Repository, NSError> {
-		fatalError()
-	}
 	class public func at(_ url: URL) -> Result<Repository, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = url.withUnsafeFileSystemRepresentation {
@@ -132,11 +128,6 @@ final public class Repository {
 	/// checkoutProgress - A block that's called with the progress of the checkout.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
-	@available(*, unavailable, renamed: "clone(from:to:localClone:bare:credentials:checkoutStrategy:checkoutProgress:)")
-	class public func cloneFromURL(_ remoteURL: URL, toURL: URL, localClone: Bool = false, bare: Bool = false,
-		credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe, checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
-		fatalError()
-	}
 	class public func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
 		credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe, checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
 			var options = cloneOptions(
@@ -217,10 +208,6 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns a `Blob`, `Commit`, `Tag`, or `Tree` if one exists, or an error.
-	@available(*, unavailable, renamed: "object(withIdentity:)")
-	public func objectWithOID(_ oid: OID) -> Result<ObjectType, NSError> {
-		fatalError()
-	}
 	public func object(withIdentity oid: OID) -> Result<ObjectType, NSError> {
 		return mapGitObject(withIdentity: oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
@@ -250,10 +237,6 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns the blob if it exists, or an error.
-	@available(*, unavailable, renamed: "blob(withIdentity:)")
-	public func blobWithOID(_ oid: OID) -> Result<Blob, NSError> {
-		fatalError()
-	}
 	public func blob(withIdentity oid: OID) -> Result<Blob, NSError> {
 		return mapGitObject(withIdentity: oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
@@ -263,10 +246,6 @@ final public class Repository {
 	/// oid - The OID of the commit to look up.
 	///
 	/// Returns the commit if it exists, or an error.
-	@available(*, unavailable, renamed: "commit(withIdentity:)")
-	public func commitWithOID(_ oid: OID) -> Result<Commit, NSError> {
-		fatalError()
-	}
 	public func commit(withIdentity oid: OID) -> Result<Commit, NSError> {
 		return mapGitObject(withIdentity: oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
@@ -276,10 +255,6 @@ final public class Repository {
 	/// oid - The OID of the tag to look up.
 	///
 	/// Returns the tag if it exists, or an error.
-	@available(*, unavailable, renamed: "tag(withIdentity:)")
-	public func tagWithOID(_ oid: OID) -> Result<Tag, NSError> {
-		fatalError()
-	}
 	public func tag(withIdentity oid: OID) -> Result<Tag, NSError> {
 		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
@@ -289,10 +264,6 @@ final public class Repository {
 	/// oid - The OID of the tree to look up.
 	///
 	/// Returns the tree if it exists, or an error.
-	@available(*, unavailable, renamed: "tree(withIdentity:)")
-	public func treeWithOID(_ oid: OID) -> Result<Tree, NSError> {
-		fatalError()
-	}
 	public func tree(withIdentity oid: OID) -> Result<Tree, NSError> {
 		return mapGitObject(withIdentity: oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
@@ -302,10 +273,6 @@ final public class Repository {
 	/// pointer - A pointer to an object.
 	///
 	/// Returns the object if it exists, or an error.
-	@available(*, unavailable, renamed: "object(from:)")
-	public func objectFromPointer<T>(_ pointer: PointerTo<T>) -> Result<T, NSError> {
-		fatalError()
-	}
 	public func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError> {
 		return mapGitObject(withIdentity: pointer.oid, type: pointer.type) { T($0) }
 	}
@@ -315,10 +282,6 @@ final public class Repository {
 	/// pointer - A pointer to an object.
 	///
 	/// Returns the object if it exists, or an error.
-	@available(*, unavailable, renamed: "object(from:)")
-	public func objectFromPointer(_ pointer: Pointer) -> Result<ObjectType, NSError> {
-		fatalError()
-	}
 	public func object(from pointer: Pointer) -> Result<ObjectType, NSError> {
 		switch pointer {
 		case let .Blob(oid):
@@ -365,10 +328,6 @@ final public class Repository {
 	/// name - The name of the remote.
 	///
 	/// Returns the remote if it exists, or an error.
-	@available(*, unavailable, renamed: "remote(withName:)")
-	public func remoteWithName(_ name: String) -> Result<Remote, NSError> {
-		fatalError()
-	}
 	public func remote(withName name: String) -> Result<Remote, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_remote_lookup(&pointer, self.pointer, name)
@@ -385,10 +344,6 @@ final public class Repository {
 	// MARK: - Reference Lookups
 	
 	/// Load all the references with the given prefix (e.g. "refs/heads/")
-	@available(*, unavailable, renamed: "references(withPrefix:)")
-	public func referencesWithPrefix(_ prefix: String) -> Result<[ReferenceType], NSError> {
-		fatalError()
-	}
 	public func references(withPrefix prefix: String) -> Result<[ReferenceType], NSError> {
 		let pointer = UnsafeMutablePointer<git_strarray>.allocate(capacity: 1)
 		let result = git_reference_list(pointer, self.pointer)
@@ -421,10 +376,6 @@ final public class Repository {
 	/// If the reference is a branch, a `Branch` will be returned. If the
 	/// reference is a tag, a `TagReference` will be returned. Otherwise, a
 	/// `Reference` will be returned.
-	@available(*, unavailable, renamed: "reference(withName:)")
-	public func referenceWithName(_ name: String) -> Result<ReferenceType, NSError> {
-		fatalError()
-	}
 	public func reference(withName name: String) -> Result<ReferenceType, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = git_reference_lookup(&pointer, self.pointer, name)
@@ -455,19 +406,11 @@ final public class Repository {
 	}
 	
 	/// Load the local branch with the given name (e.g., "master").
-	@available(*, unavailable, renamed: "localBranch(withName:)")
-	public func localBranchWithName(_ name: String) -> Result<Branch, NSError> {
-		fatalError()
-	}
 	public func localBranch(withName name: String) -> Result<Branch, NSError> {
 		return reference(withName: "refs/heads/" + name).map { $0 as! Branch }
 	}
 	
 	/// Load the remote branch with the given name (e.g., "origin/master").
-	@available(*, unavailable, renamed: "remoteBranch(withName:)")
-	public func remoteBranchWithName(_ name: String) -> Result<Branch, NSError> {
-		fatalError()
-	}
 	public func remoteBranch(withName name: String) -> Result<Branch, NSError> {
 		return reference(withName: "refs/remotes/" + name).map { $0 as! Branch }
 	}
@@ -481,10 +424,6 @@ final public class Repository {
 	}
 	
 	/// Load the tag with the given name (e.g., "tag-2").
-	@available(*, unavailable, renamed: "tag(withName:)")
-	public func tagWithName(_ name: String) -> Result<TagReference, NSError> {
-		fatalError()
-	}
 	public func tag(withName name: String) -> Result<TagReference, NSError> {
 		return reference(withName: "refs/tags/" + name).map { $0 as! TagReference }
 	}

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -217,11 +217,11 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns a `Blob`, `Commit`, `Tag`, or `Tree` if one exists, or an error.
-	@available(*, unavailable, renamed: "object(with:)")
+	@available(*, unavailable, renamed: "object(withIdentity:)")
 	public func objectWithOID(_ oid: OID) -> Result<ObjectType, NSError> {
 		fatalError()
 	}
-	public func object(with oid: OID) -> Result<ObjectType, NSError> {
+	public func object(withIdentity oid: OID) -> Result<ObjectType, NSError> {
 		return withLibgit2Object(oid, type: GIT_OBJ_ANY) { object in
 			let type = git_object_type(object)
 			if type == Blob.type {
@@ -250,11 +250,11 @@ final public class Repository {
 	/// oid - The OID of the blob to look up.
 	///
 	/// Returns the blob if it exists, or an error.
-	@available(*, unavailable, renamed: "blob(with:)")
+	@available(*, unavailable, renamed: "blob(withIdentity:)")
 	public func blobWithOID(_ oid: OID) -> Result<Blob, NSError> {
 		fatalError()
 	}
-	public func blob(with oid: OID) -> Result<Blob, NSError> {
+	public func blob(withIdentity oid: OID) -> Result<Blob, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_BLOB) { Blob($0) }
 	}
 	
@@ -263,11 +263,11 @@ final public class Repository {
 	/// oid - The OID of the commit to look up.
 	///
 	/// Returns the commit if it exists, or an error.
-	@available(*, unavailable, renamed: "commit(with:)")
+	@available(*, unavailable, renamed: "commit(withIdentity:)")
 	public func commitWithOID(_ oid: OID) -> Result<Commit, NSError> {
 		fatalError()
 	}
-	public func commit(with oid: OID) -> Result<Commit, NSError> {
+	public func commit(withIdentity oid: OID) -> Result<Commit, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_COMMIT) { Commit($0) }
 	}
 	
@@ -276,11 +276,11 @@ final public class Repository {
 	/// oid - The OID of the tag to look up.
 	///
 	/// Returns the tag if it exists, or an error.
-	@available(*, unavailable, renamed: "tag(with:)")
+	@available(*, unavailable, renamed: "tag(withIdentity:)")
 	public func tagWithOID(_ oid: OID) -> Result<Tag, NSError> {
 		fatalError()
 	}
-	public func tag(with oid: OID) -> Result<Tag, NSError> {
+	public func tag(withIdentity oid: OID) -> Result<Tag, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_TAG) { Tag($0) }
 	}
 	
@@ -289,11 +289,11 @@ final public class Repository {
 	/// oid - The OID of the tree to look up.
 	///
 	/// Returns the tree if it exists, or an error.
-	@available(*, unavailable, renamed: "tree(with:)")
+	@available(*, unavailable, renamed: "tree(withIdentity:)")
 	public func treeWithOID(_ oid: OID) -> Result<Tree, NSError> {
 		fatalError()
 	}
-	public func tree(with oid: OID) -> Result<Tree, NSError> {
+	public func tree(withIdentity oid: OID) -> Result<Tree, NSError> {
 		return self.withLibgit2Object(oid, type: GIT_OBJ_TREE) { Tree($0) }
 	}
 	
@@ -322,13 +322,13 @@ final public class Repository {
 	public func object(from pointer: Pointer) -> Result<ObjectType, NSError> {
 		switch pointer {
 		case let .Blob(oid):
-			return blob(with: oid).map { $0 as ObjectType }
+			return blob(withIdentity: oid).map { $0 as ObjectType }
 		case let .Commit(oid):
-			return commit(with: oid).map { $0 as ObjectType }
+			return commit(withIdentity: oid).map { $0 as ObjectType }
 		case let .Tag(oid):
-			return tag(with: oid).map { $0 as ObjectType }
+			return tag(withIdentity: oid).map { $0 as ObjectType }
 		case let .Tree(oid):
-			return tree(with: oid).map { $0 as ObjectType }
+			return tree(withIdentity: oid).map { $0 as ObjectType }
 		}
 	}
 	

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -54,7 +54,7 @@ final class Fixtures {
 	
 	// MARK: - Helpers
 	
-	func repositoryWithName(_ name: String) -> Repository {
+	func repository(withName name: String) -> Repository {
 		let url = directoryURL.appendingPathComponent(name, isDirectory: true)
 		return Repository.at(url).value!
 	}
@@ -62,14 +62,14 @@ final class Fixtures {
 	// MARK: - The Fixtures
 	
 	class var detachedHeadRepository: Repository {
-		return Fixtures.sharedInstance.repositoryWithName("detached-head")
+		return Fixtures.sharedInstance.repository(withName: "detached-head")
 	}
 	
 	class var simpleRepository: Repository {
-		return Fixtures.sharedInstance.repositoryWithName("simple-repository")
+		return Fixtures.sharedInstance.repository(withName: "simple-repository")
 	}
 	
 	class var mantleRepository: Repository {
-		return Fixtures.sharedInstance.repositoryWithName("Mantle")
+		return Fixtures.sharedInstance.repository(withName: "Mantle")
 	}
 }

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -56,7 +56,7 @@ final class Fixtures {
 	
 	func repositoryWithName(_ name: String) -> Repository {
 		let url = directoryURL.appendingPathComponent(name, isDirectory: true)
-		return Repository.atURL(url).value!
+		return Repository.at(url).value!
 	}
 	
 	// MARK: - The Fixtures

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -54,7 +54,7 @@ final class Fixtures {
 	
 	// MARK: - Helpers
 	
-	func repository(withName name: String) -> Repository {
+	func repository(named name: String) -> Repository {
 		let url = directoryURL.appendingPathComponent(name, isDirectory: true)
 		return Repository.at(url).value!
 	}
@@ -62,14 +62,14 @@ final class Fixtures {
 	// MARK: - The Fixtures
 	
 	class var detachedHeadRepository: Repository {
-		return Fixtures.sharedInstance.repository(withName: "detached-head")
+		return Fixtures.sharedInstance.repository(named: "detached-head")
 	}
 	
 	class var simpleRepository: Repository {
-		return Fixtures.sharedInstance.repository(withName: "simple-repository")
+		return Fixtures.sharedInstance.repository(named: "simple-repository")
 	}
 	
 	class var mantleRepository: Repository {
-		return Fixtures.sharedInstance.repository(withName: "Mantle")
+		return Fixtures.sharedInstance.repository(named: "Mantle")
 	}
 }

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -12,16 +12,18 @@ import Nimble
 import Quick
 import libgit2
 
-func from_git_object<T>(_ repository: Repository, oid: OID, f: (OpaquePointer) -> T) -> T {
-	let repository = repository.pointer
-	var oid = oid.oid
-	
-	var pointer: OpaquePointer? = nil
-	git_object_lookup(&pointer, repository, &oid, GIT_OBJ_ANY)
-	let result = f(pointer!)
-	git_object_free(pointer)
-	
-	return result
+private extension Repository {
+	func mapGitObject<T>(with oid: OID, transform: (OpaquePointer) -> T) -> T {
+		let repository = self.pointer
+		var oid = oid.oid
+
+		var pointer: OpaquePointer? = nil
+		git_object_lookup(&pointer, repository, &oid, GIT_OBJ_ANY)
+		let result = transform(pointer!)
+		git_object_free(pointer)
+
+		return result
+	}
 }
 
 class SignatureSpec: QuickSpec {
@@ -31,7 +33,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let raw_signature = from_git_object(repo, oid: oid) { git_commit_author($0).pointee }
+				let raw_signature = repo.mapGitObject(with: oid) { git_commit_author($0).pointee }
 				let signature = Signature(raw_signature)
 				
 				expect(signature.name).to(equal("Matt Diephouse"))
@@ -46,7 +48,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = from_git_object(repo, oid: oid) { commit in
+				let author1 = repo.mapGitObject(with: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -59,10 +61,10 @@ class SignatureSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let author1 = from_git_object(repo, oid: oid1) { commit in
+				let author1 = repo.mapGitObject(with: oid1) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let author2 = from_git_object(repo, oid: oid2) { commit in
+				let author2 = repo.mapGitObject(with: oid2) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				
@@ -75,7 +77,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = from_git_object(repo, oid: oid) { commit in
+				let author1 = repo.mapGitObject(with: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -93,11 +95,11 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let commit = from_git_object(repo, oid: oid) { Commit($0) }
-				let author = from_git_object(repo, oid: oid) { commit in
+				let commit = repo.mapGitObject(with: oid) { Commit($0) }
+				let author = repo.mapGitObject(with: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let committer = from_git_object(repo, oid: oid) { commit in
+				let committer = repo.mapGitObject(with: oid) { commit in
 					Signature(git_commit_committer(commit).pointee)
 				}
 				let tree = PointerTo<Tree>(OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!)
@@ -116,7 +118,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit = from_git_object(repo, oid: oid) { Commit($0) }
+				let commit = repo.mapGitObject(with: oid) { Commit($0) }
 				expect(commit.parents).to(equal([]))
 			}
 			
@@ -124,7 +126,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit = from_git_object(repo, oid: oid) { Commit($0) }
+				let commit = repo.mapGitObject(with: oid) { Commit($0) }
 				let parents: [PointerTo<Commit>] = [
 					PointerTo(OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!),
 					PointerTo(OID(string: "57f6197561d1f99b03c160f4026a07f06b43cf20")!),
@@ -138,7 +140,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = from_git_object(repo, oid: oid) { Commit($0) }
+				let commit1 = repo.mapGitObject(with: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1).to(equal(commit2))
 			}
@@ -148,8 +150,8 @@ class CommitSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit1 = from_git_object(repo, oid: oid1) { Commit($0) }
-				let commit2 = from_git_object(repo, oid: oid2) { Commit($0) }
+				let commit1 = repo.mapGitObject(with: oid1) { Commit($0) }
+				let commit2 = repo.mapGitObject(with: oid2) { Commit($0) }
 				expect(commit1).notTo(equal(commit2))
 			}
 		}
@@ -159,7 +161,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = from_git_object(repo, oid: oid) { Commit($0) }
+				let commit1 = repo.mapGitObject(with: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1.hashValue).to(equal(commit2.hashValue))
 			}
@@ -187,7 +189,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry = from_git_object(repo, oid: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry.attributes).to(equal(Int32(GIT_FILEMODE_BLOB.rawValue)))
 				expect(entry.object).to(equal(Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)))
 				expect(entry.name).to(equal("README.md"))
@@ -199,7 +201,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = from_git_object(repo, oid: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1).to(equal(entry2))
 			}
@@ -209,8 +211,8 @@ class TreeEntrySpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let entry1 = from_git_object(repo, oid: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
-				let entry2 = from_git_object(repo, oid: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(with: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry2 = repo.mapGitObject(with: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry1).notTo(equal(entry2))
 			}
 		}
@@ -220,7 +222,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = from_git_object(repo, oid: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1.hashValue).to(equal(entry2.hashValue))
 			}
@@ -235,7 +237,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree = from_git_object(repo, oid: oid) { Tree($0) }
+				let tree = repo.mapGitObject(with: oid) { Tree($0) }
 				let entries = [
 					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
 				]
@@ -248,7 +250,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = from_git_object(repo, oid: oid) { Tree($0) }
+				let tree1 = repo.mapGitObject(with: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1).to(equal(tree2))
 			}
@@ -258,8 +260,8 @@ class TreeSpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let tree1 = from_git_object(repo, oid: oid1) { Tree($0) }
-				let tree2 = from_git_object(repo, oid: oid2) { Tree($0) }
+				let tree1 = repo.mapGitObject(with: oid1) { Tree($0) }
+				let tree2 = repo.mapGitObject(with: oid2) { Tree($0) }
 				expect(tree1).notTo(equal(tree2))
 			}
 		}
@@ -269,7 +271,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = from_git_object(repo, oid: oid) { Tree($0) }
+				let tree1 = repo.mapGitObject(with: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1.hashValue).to(equal(tree2.hashValue))
 			}
@@ -284,7 +286,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob = from_git_object(repo, oid: oid) { Blob($0) }
+				let blob = repo.mapGitObject(with: oid) { Blob($0) }
 				let contents = "# Simple Repository\nA simple repository used for testing SwiftGit2.\n\n## Branches\n\n- master\n\n"
 				let data = contents.data(using: String.Encoding.utf8)!
 				expect(blob.oid).to(equal(oid))
@@ -297,7 +299,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = from_git_object(repo, oid: oid) { Blob($0) }
+				let blob1 = repo.mapGitObject(with: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1).to(equal(blob2))
 			}
@@ -307,8 +309,8 @@ class BlobSpec: QuickSpec {
 				let oid1 = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				let oid2 = OID(string: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")!
 				
-				let blob1 = from_git_object(repo, oid: oid1) { Blob($0) }
-				let blob2 = from_git_object(repo, oid: oid2) { Blob($0) }
+				let blob1 = repo.mapGitObject(with: oid1) { Blob($0) }
+				let blob2 = repo.mapGitObject(with: oid2) { Blob($0) }
 				expect(blob1).notTo(equal(blob2))
 			}
 		}
@@ -318,7 +320,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = from_git_object(repo, oid: oid) { Blob($0) }
+				let blob1 = repo.mapGitObject(with: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1.hashValue).to(equal(blob2.hashValue))
 			}
@@ -333,8 +335,8 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag = from_git_object(repo, oid: oid) { Tag($0) }
-				let tagger = from_git_object(repo, oid: oid) { Signature(git_tag_tagger($0).pointee) }
+				let tag = repo.mapGitObject(with: oid) { Tag($0) }
+				let tagger = repo.mapGitObject(with: oid) { Signature(git_tag_tagger($0).pointee) }
 				
 				expect(tag.oid).to(equal(oid))
 				expect(tag.target).to(equal(Pointer.Commit(OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!)))
@@ -349,7 +351,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = from_git_object(repo, oid: oid) { Tag($0) }
+				let tag1 = repo.mapGitObject(with: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1).to(equal(tag2))
 			}
@@ -359,8 +361,8 @@ class TagSpec: QuickSpec {
 				let oid1 = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				let oid2 = OID(string: "13bda91157f255ab224ff88d0a11a82041c9d0c1")!
 				
-				let tag1 = from_git_object(repo, oid: oid1) { Tag($0) }
-				let tag2 = from_git_object(repo, oid: oid2) { Tag($0) }
+				let tag1 = repo.mapGitObject(with: oid1) { Tag($0) }
+				let tag2 = repo.mapGitObject(with: oid2) { Tag($0) }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -370,7 +372,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = from_git_object(repo, oid: oid) { Tag($0) }
+				let tag1 = repo.mapGitObject(with: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func withGitObject<T>(withIdentity oid: OID, transform: (OpaquePointer) -> T) -> T {
+	func withGitObject<T>(_ oid: OID, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 		var oid = oid.oid
 
@@ -33,7 +33,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let raw_signature = repo.withGitObject(withIdentity: oid) { git_commit_author($0).pointee }
+				let raw_signature = repo.withGitObject(oid) { git_commit_author($0).pointee }
 				let signature = Signature(raw_signature)
 				
 				expect(signature.name).to(equal("Matt Diephouse"))
@@ -48,7 +48,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.withGitObject(withIdentity: oid) { commit in
+				let author1 = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -61,10 +61,10 @@ class SignatureSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let author1 = repo.withGitObject(withIdentity: oid1) { commit in
+				let author1 = repo.withGitObject(oid1) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let author2 = repo.withGitObject(withIdentity: oid2) { commit in
+				let author2 = repo.withGitObject(oid2) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				
@@ -77,7 +77,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.withGitObject(withIdentity: oid) { commit in
+				let author1 = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -95,11 +95,11 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
-				let author = repo.withGitObject(withIdentity: oid) { commit in
+				let commit = repo.withGitObject(oid) { Commit($0) }
+				let author = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let committer = repo.withGitObject(withIdentity: oid) { commit in
+				let committer = repo.withGitObject(oid) { commit in
 					Signature(git_commit_committer(commit).pointee)
 				}
 				let tree = PointerTo<Tree>(OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!)
@@ -118,7 +118,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
+				let commit = repo.withGitObject(oid) { Commit($0) }
 				expect(commit.parents).to(equal([]))
 			}
 			
@@ -126,7 +126,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
+				let commit = repo.withGitObject(oid) { Commit($0) }
 				let parents: [PointerTo<Commit>] = [
 					PointerTo(OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!),
 					PointerTo(OID(string: "57f6197561d1f99b03c160f4026a07f06b43cf20")!),
@@ -140,7 +140,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.withGitObject(withIdentity: oid) { Commit($0) }
+				let commit1 = repo.withGitObject(oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1).to(equal(commit2))
 			}
@@ -150,8 +150,8 @@ class CommitSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit1 = repo.withGitObject(withIdentity: oid1) { Commit($0) }
-				let commit2 = repo.withGitObject(withIdentity: oid2) { Commit($0) }
+				let commit1 = repo.withGitObject(oid1) { Commit($0) }
+				let commit2 = repo.withGitObject(oid2) { Commit($0) }
 				expect(commit1).notTo(equal(commit2))
 			}
 		}
@@ -161,7 +161,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.withGitObject(withIdentity: oid) { Commit($0) }
+				let commit1 = repo.withGitObject(oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1.hashValue).to(equal(commit2.hashValue))
 			}
@@ -189,7 +189,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry.attributes).to(equal(Int32(GIT_FILEMODE_BLOB.rawValue)))
 				expect(entry.object).to(equal(Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)))
 				expect(entry.name).to(equal("README.md"))
@@ -201,7 +201,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1).to(equal(entry2))
 			}
@@ -211,8 +211,8 @@ class TreeEntrySpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let entry1 = repo.withGitObject(withIdentity: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
-				let entry2 = repo.withGitObject(withIdentity: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry2 = repo.withGitObject(oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry1).notTo(equal(entry2))
 			}
 		}
@@ -222,7 +222,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1.hashValue).to(equal(entry2.hashValue))
 			}
@@ -237,7 +237,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree = repo.withGitObject(withIdentity: oid) { Tree($0) }
+				let tree = repo.withGitObject(oid) { Tree($0) }
 				let entries = [
 					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
 				]
@@ -250,7 +250,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.withGitObject(withIdentity: oid) { Tree($0) }
+				let tree1 = repo.withGitObject(oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1).to(equal(tree2))
 			}
@@ -260,8 +260,8 @@ class TreeSpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let tree1 = repo.withGitObject(withIdentity: oid1) { Tree($0) }
-				let tree2 = repo.withGitObject(withIdentity: oid2) { Tree($0) }
+				let tree1 = repo.withGitObject(oid1) { Tree($0) }
+				let tree2 = repo.withGitObject(oid2) { Tree($0) }
 				expect(tree1).notTo(equal(tree2))
 			}
 		}
@@ -271,7 +271,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.withGitObject(withIdentity: oid) { Tree($0) }
+				let tree1 = repo.withGitObject(oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1.hashValue).to(equal(tree2.hashValue))
 			}
@@ -286,7 +286,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob = repo.withGitObject(withIdentity: oid) { Blob($0) }
+				let blob = repo.withGitObject(oid) { Blob($0) }
 				let contents = "# Simple Repository\nA simple repository used for testing SwiftGit2.\n\n## Branches\n\n- master\n\n"
 				let data = contents.data(using: String.Encoding.utf8)!
 				expect(blob.oid).to(equal(oid))
@@ -299,7 +299,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.withGitObject(withIdentity: oid) { Blob($0) }
+				let blob1 = repo.withGitObject(oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1).to(equal(blob2))
 			}
@@ -309,8 +309,8 @@ class BlobSpec: QuickSpec {
 				let oid1 = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				let oid2 = OID(string: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")!
 				
-				let blob1 = repo.withGitObject(withIdentity: oid1) { Blob($0) }
-				let blob2 = repo.withGitObject(withIdentity: oid2) { Blob($0) }
+				let blob1 = repo.withGitObject(oid1) { Blob($0) }
+				let blob2 = repo.withGitObject(oid2) { Blob($0) }
 				expect(blob1).notTo(equal(blob2))
 			}
 		}
@@ -320,7 +320,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.withGitObject(withIdentity: oid) { Blob($0) }
+				let blob1 = repo.withGitObject(oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1.hashValue).to(equal(blob2.hashValue))
 			}
@@ -335,8 +335,8 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag = repo.withGitObject(withIdentity: oid) { Tag($0) }
-				let tagger = repo.withGitObject(withIdentity: oid) { Signature(git_tag_tagger($0).pointee) }
+				let tag = repo.withGitObject(oid) { Tag($0) }
+				let tagger = repo.withGitObject(oid) { Signature(git_tag_tagger($0).pointee) }
 				
 				expect(tag.oid).to(equal(oid))
 				expect(tag.target).to(equal(Pointer.Commit(OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!)))
@@ -351,7 +351,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.withGitObject(withIdentity: oid) { Tag($0) }
+				let tag1 = repo.withGitObject(oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1).to(equal(tag2))
 			}
@@ -361,8 +361,8 @@ class TagSpec: QuickSpec {
 				let oid1 = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				let oid2 = OID(string: "13bda91157f255ab224ff88d0a11a82041c9d0c1")!
 				
-				let tag1 = repo.withGitObject(withIdentity: oid1) { Tag($0) }
-				let tag2 = repo.withGitObject(withIdentity: oid2) { Tag($0) }
+				let tag1 = repo.withGitObject(oid1) { Tag($0) }
+				let tag2 = repo.withGitObject(oid2) { Tag($0) }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -372,7 +372,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.withGitObject(withIdentity: oid) { Tag($0) }
+				let tag1 = repo.withGitObject(oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func mapGitObject<T>(withIdentity oid: OID, transform: (OpaquePointer) -> T) -> T {
+	func withGitObject<T>(withIdentity oid: OID, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 		var oid = oid.oid
 
@@ -33,7 +33,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let raw_signature = repo.mapGitObject(withIdentity: oid) { git_commit_author($0).pointee }
+				let raw_signature = repo.withGitObject(withIdentity: oid) { git_commit_author($0).pointee }
 				let signature = Signature(raw_signature)
 				
 				expect(signature.name).to(equal("Matt Diephouse"))
@@ -48,7 +48,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.mapGitObject(withIdentity: oid) { commit in
+				let author1 = repo.withGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -61,10 +61,10 @@ class SignatureSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let author1 = repo.mapGitObject(withIdentity: oid1) { commit in
+				let author1 = repo.withGitObject(withIdentity: oid1) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let author2 = repo.mapGitObject(withIdentity: oid2) { commit in
+				let author2 = repo.withGitObject(withIdentity: oid2) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				
@@ -77,7 +77,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.mapGitObject(withIdentity: oid) { commit in
+				let author1 = repo.withGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -95,11 +95,11 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
-				let author = repo.mapGitObject(withIdentity: oid) { commit in
+				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
+				let author = repo.withGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let committer = repo.mapGitObject(withIdentity: oid) { commit in
+				let committer = repo.withGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_committer(commit).pointee)
 				}
 				let tree = PointerTo<Tree>(OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!)
@@ -118,7 +118,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
+				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
 				expect(commit.parents).to(equal([]))
 			}
 			
@@ -126,7 +126,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
+				let commit = repo.withGitObject(withIdentity: oid) { Commit($0) }
 				let parents: [PointerTo<Commit>] = [
 					PointerTo(OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!),
 					PointerTo(OID(string: "57f6197561d1f99b03c160f4026a07f06b43cf20")!),
@@ -140,7 +140,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.mapGitObject(withIdentity: oid) { Commit($0) }
+				let commit1 = repo.withGitObject(withIdentity: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1).to(equal(commit2))
 			}
@@ -150,8 +150,8 @@ class CommitSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit1 = repo.mapGitObject(withIdentity: oid1) { Commit($0) }
-				let commit2 = repo.mapGitObject(withIdentity: oid2) { Commit($0) }
+				let commit1 = repo.withGitObject(withIdentity: oid1) { Commit($0) }
+				let commit2 = repo.withGitObject(withIdentity: oid2) { Commit($0) }
 				expect(commit1).notTo(equal(commit2))
 			}
 		}
@@ -161,7 +161,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.mapGitObject(withIdentity: oid) { Commit($0) }
+				let commit1 = repo.withGitObject(withIdentity: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1.hashValue).to(equal(commit2.hashValue))
 			}
@@ -189,7 +189,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry.attributes).to(equal(Int32(GIT_FILEMODE_BLOB.rawValue)))
 				expect(entry.object).to(equal(Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)))
 				expect(entry.name).to(equal("README.md"))
@@ -201,7 +201,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1).to(equal(entry2))
 			}
@@ -211,8 +211,8 @@ class TreeEntrySpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let entry1 = repo.mapGitObject(withIdentity: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
-				let entry2 = repo.mapGitObject(withIdentity: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(withIdentity: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry2 = repo.withGitObject(withIdentity: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry1).notTo(equal(entry2))
 			}
 		}
@@ -222,7 +222,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.withGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1.hashValue).to(equal(entry2.hashValue))
 			}
@@ -237,7 +237,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree = repo.mapGitObject(withIdentity: oid) { Tree($0) }
+				let tree = repo.withGitObject(withIdentity: oid) { Tree($0) }
 				let entries = [
 					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
 				]
@@ -250,7 +250,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.mapGitObject(withIdentity: oid) { Tree($0) }
+				let tree1 = repo.withGitObject(withIdentity: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1).to(equal(tree2))
 			}
@@ -260,8 +260,8 @@ class TreeSpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let tree1 = repo.mapGitObject(withIdentity: oid1) { Tree($0) }
-				let tree2 = repo.mapGitObject(withIdentity: oid2) { Tree($0) }
+				let tree1 = repo.withGitObject(withIdentity: oid1) { Tree($0) }
+				let tree2 = repo.withGitObject(withIdentity: oid2) { Tree($0) }
 				expect(tree1).notTo(equal(tree2))
 			}
 		}
@@ -271,7 +271,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.mapGitObject(withIdentity: oid) { Tree($0) }
+				let tree1 = repo.withGitObject(withIdentity: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1.hashValue).to(equal(tree2.hashValue))
 			}
@@ -286,7 +286,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob = repo.mapGitObject(withIdentity: oid) { Blob($0) }
+				let blob = repo.withGitObject(withIdentity: oid) { Blob($0) }
 				let contents = "# Simple Repository\nA simple repository used for testing SwiftGit2.\n\n## Branches\n\n- master\n\n"
 				let data = contents.data(using: String.Encoding.utf8)!
 				expect(blob.oid).to(equal(oid))
@@ -299,7 +299,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.mapGitObject(withIdentity: oid) { Blob($0) }
+				let blob1 = repo.withGitObject(withIdentity: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1).to(equal(blob2))
 			}
@@ -309,8 +309,8 @@ class BlobSpec: QuickSpec {
 				let oid1 = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				let oid2 = OID(string: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")!
 				
-				let blob1 = repo.mapGitObject(withIdentity: oid1) { Blob($0) }
-				let blob2 = repo.mapGitObject(withIdentity: oid2) { Blob($0) }
+				let blob1 = repo.withGitObject(withIdentity: oid1) { Blob($0) }
+				let blob2 = repo.withGitObject(withIdentity: oid2) { Blob($0) }
 				expect(blob1).notTo(equal(blob2))
 			}
 		}
@@ -320,7 +320,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.mapGitObject(withIdentity: oid) { Blob($0) }
+				let blob1 = repo.withGitObject(withIdentity: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1.hashValue).to(equal(blob2.hashValue))
 			}
@@ -335,8 +335,8 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag = repo.mapGitObject(withIdentity: oid) { Tag($0) }
-				let tagger = repo.mapGitObject(withIdentity: oid) { Signature(git_tag_tagger($0).pointee) }
+				let tag = repo.withGitObject(withIdentity: oid) { Tag($0) }
+				let tagger = repo.withGitObject(withIdentity: oid) { Signature(git_tag_tagger($0).pointee) }
 				
 				expect(tag.oid).to(equal(oid))
 				expect(tag.target).to(equal(Pointer.Commit(OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!)))
@@ -351,7 +351,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.mapGitObject(withIdentity: oid) { Tag($0) }
+				let tag1 = repo.withGitObject(withIdentity: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1).to(equal(tag2))
 			}
@@ -361,8 +361,8 @@ class TagSpec: QuickSpec {
 				let oid1 = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				let oid2 = OID(string: "13bda91157f255ab224ff88d0a11a82041c9d0c1")!
 				
-				let tag1 = repo.mapGitObject(withIdentity: oid1) { Tag($0) }
-				let tag2 = repo.mapGitObject(withIdentity: oid2) { Tag($0) }
+				let tag1 = repo.withGitObject(withIdentity: oid1) { Tag($0) }
+				let tag2 = repo.withGitObject(withIdentity: oid2) { Tag($0) }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -372,7 +372,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.mapGitObject(withIdentity: oid) { Tag($0) }
+				let tag1 = repo.withGitObject(withIdentity: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func mapGitObject<T>(with oid: OID, transform: (OpaquePointer) -> T) -> T {
+	func mapGitObject<T>(withIdentity oid: OID, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 		var oid = oid.oid
 
@@ -33,7 +33,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let raw_signature = repo.mapGitObject(with: oid) { git_commit_author($0).pointee }
+				let raw_signature = repo.mapGitObject(withIdentity: oid) { git_commit_author($0).pointee }
 				let signature = Signature(raw_signature)
 				
 				expect(signature.name).to(equal("Matt Diephouse"))
@@ -48,7 +48,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.mapGitObject(with: oid) { commit in
+				let author1 = repo.mapGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -61,10 +61,10 @@ class SignatureSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let author1 = repo.mapGitObject(with: oid1) { commit in
+				let author1 = repo.mapGitObject(withIdentity: oid1) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let author2 = repo.mapGitObject(with: oid2) { commit in
+				let author2 = repo.mapGitObject(withIdentity: oid2) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				
@@ -77,7 +77,7 @@ class SignatureSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let author1 = repo.mapGitObject(with: oid) { commit in
+				let author1 = repo.mapGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
@@ -95,11 +95,11 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
 				
-				let commit = repo.mapGitObject(with: oid) { Commit($0) }
-				let author = repo.mapGitObject(with: oid) { commit in
+				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
+				let author = repo.mapGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				let committer = repo.mapGitObject(with: oid) { commit in
+				let committer = repo.mapGitObject(withIdentity: oid) { commit in
 					Signature(git_commit_committer(commit).pointee)
 				}
 				let tree = PointerTo<Tree>(OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!)
@@ -118,7 +118,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit = repo.mapGitObject(with: oid) { Commit($0) }
+				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
 				expect(commit.parents).to(equal([]))
 			}
 			
@@ -126,7 +126,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit = repo.mapGitObject(with: oid) { Commit($0) }
+				let commit = repo.mapGitObject(withIdentity: oid) { Commit($0) }
 				let parents: [PointerTo<Commit>] = [
 					PointerTo(OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!),
 					PointerTo(OID(string: "57f6197561d1f99b03c160f4026a07f06b43cf20")!),
@@ -140,7 +140,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.mapGitObject(with: oid) { Commit($0) }
+				let commit1 = repo.mapGitObject(withIdentity: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1).to(equal(commit2))
 			}
@@ -150,8 +150,8 @@ class CommitSpec: QuickSpec {
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
 				
-				let commit1 = repo.mapGitObject(with: oid1) { Commit($0) }
-				let commit2 = repo.mapGitObject(with: oid2) { Commit($0) }
+				let commit1 = repo.mapGitObject(withIdentity: oid1) { Commit($0) }
+				let commit2 = repo.mapGitObject(withIdentity: oid2) { Commit($0) }
 				expect(commit1).notTo(equal(commit2))
 			}
 		}
@@ -161,7 +161,7 @@ class CommitSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let commit1 = repo.mapGitObject(with: oid) { Commit($0) }
+				let commit1 = repo.mapGitObject(withIdentity: oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1.hashValue).to(equal(commit2.hashValue))
 			}
@@ -189,7 +189,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry.attributes).to(equal(Int32(GIT_FILEMODE_BLOB.rawValue)))
 				expect(entry.object).to(equal(Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)))
 				expect(entry.name).to(equal("README.md"))
@@ -201,7 +201,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1).to(equal(entry2))
 			}
@@ -211,8 +211,8 @@ class TreeEntrySpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let entry1 = repo.mapGitObject(with: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
-				let entry2 = repo.mapGitObject(with: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(withIdentity: oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry2 = repo.mapGitObject(withIdentity: oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry1).notTo(equal(entry2))
 			}
 		}
@@ -222,7 +222,7 @@ class TreeEntrySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let entry1 = repo.mapGitObject(with: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
+				let entry1 = repo.mapGitObject(withIdentity: oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1.hashValue).to(equal(entry2.hashValue))
 			}
@@ -237,7 +237,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree = repo.mapGitObject(with: oid) { Tree($0) }
+				let tree = repo.mapGitObject(withIdentity: oid) { Tree($0) }
 				let entries = [
 					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
 				]
@@ -250,7 +250,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.mapGitObject(with: oid) { Tree($0) }
+				let tree1 = repo.mapGitObject(withIdentity: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1).to(equal(tree2))
 			}
@@ -260,8 +260,8 @@ class TreeSpec: QuickSpec {
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let tree1 = repo.mapGitObject(with: oid1) { Tree($0) }
-				let tree2 = repo.mapGitObject(with: oid2) { Tree($0) }
+				let tree1 = repo.mapGitObject(withIdentity: oid1) { Tree($0) }
+				let tree2 = repo.mapGitObject(withIdentity: oid2) { Tree($0) }
 				expect(tree1).notTo(equal(tree2))
 			}
 		}
@@ -271,7 +271,7 @@ class TreeSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				
-				let tree1 = repo.mapGitObject(with: oid) { Tree($0) }
+				let tree1 = repo.mapGitObject(withIdentity: oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1.hashValue).to(equal(tree2.hashValue))
 			}
@@ -286,7 +286,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob = repo.mapGitObject(with: oid) { Blob($0) }
+				let blob = repo.mapGitObject(withIdentity: oid) { Blob($0) }
 				let contents = "# Simple Repository\nA simple repository used for testing SwiftGit2.\n\n## Branches\n\n- master\n\n"
 				let data = contents.data(using: String.Encoding.utf8)!
 				expect(blob.oid).to(equal(oid))
@@ -299,7 +299,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.mapGitObject(with: oid) { Blob($0) }
+				let blob1 = repo.mapGitObject(withIdentity: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1).to(equal(blob2))
 			}
@@ -309,8 +309,8 @@ class BlobSpec: QuickSpec {
 				let oid1 = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				let oid2 = OID(string: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")!
 				
-				let blob1 = repo.mapGitObject(with: oid1) { Blob($0) }
-				let blob2 = repo.mapGitObject(with: oid2) { Blob($0) }
+				let blob1 = repo.mapGitObject(withIdentity: oid1) { Blob($0) }
+				let blob2 = repo.mapGitObject(withIdentity: oid2) { Blob($0) }
 				expect(blob1).notTo(equal(blob2))
 			}
 		}
@@ -320,7 +320,7 @@ class BlobSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let blob1 = repo.mapGitObject(with: oid) { Blob($0) }
+				let blob1 = repo.mapGitObject(withIdentity: oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1.hashValue).to(equal(blob2.hashValue))
 			}
@@ -335,8 +335,8 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag = repo.mapGitObject(with: oid) { Tag($0) }
-				let tagger = repo.mapGitObject(with: oid) { Signature(git_tag_tagger($0).pointee) }
+				let tag = repo.mapGitObject(withIdentity: oid) { Tag($0) }
+				let tagger = repo.mapGitObject(withIdentity: oid) { Signature(git_tag_tagger($0).pointee) }
 				
 				expect(tag.oid).to(equal(oid))
 				expect(tag.target).to(equal(Pointer.Commit(OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!)))
@@ -351,7 +351,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.mapGitObject(with: oid) { Tag($0) }
+				let tag1 = repo.mapGitObject(withIdentity: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1).to(equal(tag2))
 			}
@@ -361,8 +361,8 @@ class TagSpec: QuickSpec {
 				let oid1 = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				let oid2 = OID(string: "13bda91157f255ab224ff88d0a11a82041c9d0c1")!
 				
-				let tag1 = repo.mapGitObject(with: oid1) { Tag($0) }
-				let tag2 = repo.mapGitObject(with: oid2) { Tag($0) }
+				let tag1 = repo.mapGitObject(withIdentity: oid1) { Tag($0) }
+				let tag2 = repo.mapGitObject(withIdentity: oid2) { Tag($0) }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -372,7 +372,7 @@ class TagSpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let tag1 = repo.mapGitObject(with: oid) { Tag($0) }
+				let tag1 = repo.mapGitObject(withIdentity: oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func mapGitReference<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
+	func withGitReference<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 
 		var pointer: OpaquePointer? = nil
@@ -30,7 +30,7 @@ class ReferenceSpec: QuickSpec {
 		describe("Reference(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
-				let ref = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
 				expect(ref.longName).to(equal("refs/heads/master"))
 				expect(ref.shortName).to(equal("master"))
 				expect(ref.oid).to(equal(OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!))
@@ -40,15 +40,15 @@ class ReferenceSpec: QuickSpec {
 		describe("==(Reference, Reference)") {
 			it("should be true with equal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
 				expect(ref1).to(equal(ref2))
 			}
 			
 			it("should be false with unequal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.mapGitReference(withName: "refs/heads/another-branch") { Reference($0) }
+				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(withName: "refs/heads/another-branch") { Reference($0) }
 				expect(ref1).notTo(equal(ref2))
 			}
 		}
@@ -56,8 +56,8 @@ class ReferenceSpec: QuickSpec {
 		describe("Reference.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.mapGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
 				expect(ref1.hashValue).to(equal(ref2.hashValue))
 			}
 		}
@@ -69,7 +69,7 @@ class BranchSpec: QuickSpec {
 		describe("Branch(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
-				let branch = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
 				expect(branch.longName).to(equal("refs/heads/master"))
 				expect(branch.name).to(equal("master"))
 				expect(branch.shortName).to(equal(branch.name))
@@ -81,7 +81,7 @@ class BranchSpec: QuickSpec {
 			
 			it("should work with symoblic refs") {
 				let repo = Fixtures.mantleRepository
-				let branch = repo.mapGitReference(withName: "refs/remotes/origin/HEAD") { Branch($0)! }
+				let branch = repo.withGitReference(withName: "refs/remotes/origin/HEAD") { Branch($0)! }
 				expect(branch.longName).to(equal("refs/remotes/origin/HEAD"))
 				expect(branch.name).to(equal("origin/HEAD"))
 				expect(branch.shortName).to(equal(branch.name))
@@ -95,15 +95,15 @@ class BranchSpec: QuickSpec {
 		describe("==(Branch, Branch)") {
 			it("should be true with equal branches") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
 				expect(branch1).to(equal(branch2))
 			}
 			
 			it("should be false with unequal branches") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.mapGitReference(withName: "refs/heads/another-branch") { Branch($0)! }
+				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(withName: "refs/heads/another-branch") { Branch($0)! }
 				expect(branch1).notTo(equal(branch2))
 			}
 		}
@@ -111,8 +111,8 @@ class BranchSpec: QuickSpec {
 		describe("Branch.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.mapGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
 				expect(branch1.hashValue).to(equal(branch2.hashValue))
 			}
 		}
@@ -124,7 +124,7 @@ class TagReferenceSpec: QuickSpec {
 		describe("TagReference(pointer)") {
 			it("should work with an annotated tag") {
 				let repo = Fixtures.simpleRepository
-				let tag = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag.longName).to(equal("refs/tags/tag-2"))
 				expect(tag.name).to(equal("tag-2"))
 				expect(tag.shortName).to(equal(tag.name))
@@ -133,7 +133,7 @@ class TagReferenceSpec: QuickSpec {
 			
 			it("should work with a lightweight tag") {
 				let repo = Fixtures.mantleRepository
-				let tag = repo.mapGitReference(withName: "refs/tags/1.5.4") { TagReference($0)! }
+				let tag = repo.withGitReference(withName: "refs/tags/1.5.4") { TagReference($0)! }
 				expect(tag.longName).to(equal("refs/tags/1.5.4"))
 				expect(tag.name).to(equal("1.5.4"))
 				expect(tag.shortName).to(equal(tag.name))
@@ -142,7 +142,7 @@ class TagReferenceSpec: QuickSpec {
 			
 			it("should return nil if not a tag") {
 				let repo = Fixtures.simpleRepository
-				let tag = repo.mapGitReference(withName: "refs/heads/master") { TagReference($0) }
+				let tag = repo.withGitReference(withName: "refs/heads/master") { TagReference($0) }
 				expect(tag).to(beNil())
 			}
 		}
@@ -150,15 +150,15 @@ class TagReferenceSpec: QuickSpec {
 		describe("==(TagReference, TagReference)") {
 			it("should be true with equal tag references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
-				let tag2 = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1).to(equal(tag2))
 			}
 			
 			it("should be false with unequal tag references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.mapGitReference(withName: "refs/tags/tag-1") { TagReference($0)! }
-				let tag2 = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(withName: "refs/tags/tag-1") { TagReference($0)! }
+				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -166,8 +166,8 @@ class TagReferenceSpec: QuickSpec {
 		describe("TagReference.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
-				let tag2 = repo.mapGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}
 		}

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func withGitReference<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
+	func withGitReference<T>(named name: String, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 
 		var pointer: OpaquePointer? = nil
@@ -30,7 +30,7 @@ class ReferenceSpec: QuickSpec {
 		describe("Reference(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
-				let ref = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
 				expect(ref.longName).to(equal("refs/heads/master"))
 				expect(ref.shortName).to(equal("master"))
 				expect(ref.oid).to(equal(OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!))
@@ -40,15 +40,15 @@ class ReferenceSpec: QuickSpec {
 		describe("==(Reference, Reference)") {
 			it("should be true with equal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref1 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
 				expect(ref1).to(equal(ref2))
 			}
 			
 			it("should be false with unequal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.withGitReference(withName: "refs/heads/another-branch") { Reference($0) }
+				let ref1 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(named: "refs/heads/another-branch") { Reference($0) }
 				expect(ref1).notTo(equal(ref2))
 			}
 		}
@@ -56,8 +56,8 @@ class ReferenceSpec: QuickSpec {
 		describe("Reference.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let ref1 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
-				let ref2 = repo.withGitReference(withName: "refs/heads/master") { Reference($0) }
+				let ref1 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
+				let ref2 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
 				expect(ref1.hashValue).to(equal(ref2.hashValue))
 			}
 		}
@@ -69,7 +69,7 @@ class BranchSpec: QuickSpec {
 		describe("Branch(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
-				let branch = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
 				expect(branch.longName).to(equal("refs/heads/master"))
 				expect(branch.name).to(equal("master"))
 				expect(branch.shortName).to(equal(branch.name))
@@ -81,7 +81,7 @@ class BranchSpec: QuickSpec {
 			
 			it("should work with symoblic refs") {
 				let repo = Fixtures.mantleRepository
-				let branch = repo.withGitReference(withName: "refs/remotes/origin/HEAD") { Branch($0)! }
+				let branch = repo.withGitReference(named: "refs/remotes/origin/HEAD") { Branch($0)! }
 				expect(branch.longName).to(equal("refs/remotes/origin/HEAD"))
 				expect(branch.name).to(equal("origin/HEAD"))
 				expect(branch.shortName).to(equal(branch.name))
@@ -95,15 +95,15 @@ class BranchSpec: QuickSpec {
 		describe("==(Branch, Branch)") {
 			it("should be true with equal branches") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch1 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
 				expect(branch1).to(equal(branch2))
 			}
 			
 			it("should be false with unequal branches") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.withGitReference(withName: "refs/heads/another-branch") { Branch($0)! }
+				let branch1 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(named: "refs/heads/another-branch") { Branch($0)! }
 				expect(branch1).notTo(equal(branch2))
 			}
 		}
@@ -111,8 +111,8 @@ class BranchSpec: QuickSpec {
 		describe("Branch.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let branch1 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
-				let branch2 = repo.withGitReference(withName: "refs/heads/master") { Branch($0)! }
+				let branch1 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
+				let branch2 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
 				expect(branch1.hashValue).to(equal(branch2.hashValue))
 			}
 		}
@@ -124,7 +124,7 @@ class TagReferenceSpec: QuickSpec {
 		describe("TagReference(pointer)") {
 			it("should work with an annotated tag") {
 				let repo = Fixtures.simpleRepository
-				let tag = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag.longName).to(equal("refs/tags/tag-2"))
 				expect(tag.name).to(equal("tag-2"))
 				expect(tag.shortName).to(equal(tag.name))
@@ -133,7 +133,7 @@ class TagReferenceSpec: QuickSpec {
 			
 			it("should work with a lightweight tag") {
 				let repo = Fixtures.mantleRepository
-				let tag = repo.withGitReference(withName: "refs/tags/1.5.4") { TagReference($0)! }
+				let tag = repo.withGitReference(named: "refs/tags/1.5.4") { TagReference($0)! }
 				expect(tag.longName).to(equal("refs/tags/1.5.4"))
 				expect(tag.name).to(equal("1.5.4"))
 				expect(tag.shortName).to(equal(tag.name))
@@ -142,7 +142,7 @@ class TagReferenceSpec: QuickSpec {
 			
 			it("should return nil if not a tag") {
 				let repo = Fixtures.simpleRepository
-				let tag = repo.withGitReference(withName: "refs/heads/master") { TagReference($0) }
+				let tag = repo.withGitReference(named: "refs/heads/master") { TagReference($0) }
 				expect(tag).to(beNil())
 			}
 		}
@@ -150,15 +150,15 @@ class TagReferenceSpec: QuickSpec {
 		describe("==(TagReference, TagReference)") {
 			it("should be true with equal tag references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
-				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
+				let tag2 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1).to(equal(tag2))
 			}
 			
 			it("should be false with unequal tag references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.withGitReference(withName: "refs/tags/tag-1") { TagReference($0)! }
-				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(named: "refs/tags/tag-1") { TagReference($0)! }
+				let tag2 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
@@ -166,8 +166,8 @@ class TagReferenceSpec: QuickSpec {
 		describe("TagReference.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository
-				let tag1 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
-				let tag2 = repo.withGitReference(withName: "refs/tags/tag-2") { TagReference($0)! }
+				let tag1 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
+				let tag2 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1.hashValue).to(equal(tag2.hashValue))
 			}
 		}

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func withGitRemote<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
+	func withGitRemote<T>(named name: String, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 
 		var pointer: OpaquePointer? = nil
@@ -30,7 +30,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
-				let remote = repo.withGitRemote(withName: "upstream") { Remote($0) }
+				let remote = repo.withGitRemote(named: "upstream") { Remote($0) }
 				
 				expect(remote.name).to(equal("upstream"))
 				expect(remote.URL).to(equal("git@github.com:Mantle/Mantle.git"))
@@ -40,15 +40,15 @@ class RemoteSpec: QuickSpec {
 		describe("==(Remote, Remote)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = repo.withGitRemote(withName: "upstream") { Remote($0) }
+				let remote1 = repo.withGitRemote(named: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1).to(equal(remote2))
 			}
 			
 			it("should be false with unequal objcets") {
 				let repo = Fixtures.mantleRepository
-				let origin = repo.withGitRemote(withName: "origin") { Remote($0) }
-				let upstream = repo.withGitRemote(withName: "upstream") { Remote($0) }
+				let origin = repo.withGitRemote(named: "origin") { Remote($0) }
+				let upstream = repo.withGitRemote(named: "upstream") { Remote($0) }
 				expect(origin).notTo(equal(upstream))
 			}
 		}
@@ -56,7 +56,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote.hashValue") {
 			it("should be equal with equal objcets") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = repo.withGitRemote(withName: "upstream") { Remote($0) }
+				let remote1 = repo.withGitRemote(named: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1.hashValue).to(equal(remote2.hashValue))
 			}

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -12,15 +12,17 @@ import Nimble
 import Quick
 import libgit2
 
-func with_git_remote<T>(_ repository: Repository, name: String, f: (OpaquePointer) -> T) -> T {
-	let repository = repository.pointer
-	
-	var pointer: OpaquePointer? = nil
-	git_remote_lookup(&pointer, repository, name)
-	let result = f(pointer!)
-	git_object_free(pointer)
-	
-	return result
+private extension Repository {
+	func mapGitRemote<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
+		let repository = self.pointer
+
+		var pointer: OpaquePointer? = nil
+		git_remote_lookup(&pointer, repository, name)
+		let result = transform(pointer!)
+		git_remote_free(pointer)
+
+		return result
+	}
 }
 
 class RemoteSpec: QuickSpec {
@@ -28,7 +30,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
-				let remote = with_git_remote(repo, name: "upstream") { Remote($0) }
+				let remote = repo.mapGitRemote(withName: "upstream") { Remote($0) }
 				
 				expect(remote.name).to(equal("upstream"))
 				expect(remote.URL).to(equal("git@github.com:Mantle/Mantle.git"))
@@ -38,15 +40,15 @@ class RemoteSpec: QuickSpec {
 		describe("==(Remote, Remote)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = with_git_remote(repo, name: "upstream") { Remote($0) }
+				let remote1 = repo.mapGitRemote(withName: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1).to(equal(remote2))
 			}
 			
 			it("should be false with unequal objcets") {
 				let repo = Fixtures.mantleRepository
-				let origin = with_git_remote(repo, name: "origin") { Remote($0) }
-				let upstream = with_git_remote(repo, name: "upstream") { Remote($0) }
+				let origin = repo.mapGitRemote(withName: "origin") { Remote($0) }
+				let upstream = repo.mapGitRemote(withName: "upstream") { Remote($0) }
 				expect(origin).notTo(equal(upstream))
 			}
 		}
@@ -54,7 +56,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote.hashValue") {
 			it("should be equal with equal objcets") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = with_git_remote(repo, name: "upstream") { Remote($0) }
+				let remote1 = repo.mapGitRemote(withName: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1.hashValue).to(equal(remote2.hashValue))
 			}

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -13,7 +13,7 @@ import Quick
 import libgit2
 
 private extension Repository {
-	func mapGitRemote<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
+	func withGitRemote<T>(withName name: String, transform: (OpaquePointer) -> T) -> T {
 		let repository = self.pointer
 
 		var pointer: OpaquePointer? = nil
@@ -30,7 +30,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote(pointer)") {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
-				let remote = repo.mapGitRemote(withName: "upstream") { Remote($0) }
+				let remote = repo.withGitRemote(withName: "upstream") { Remote($0) }
 				
 				expect(remote.name).to(equal("upstream"))
 				expect(remote.URL).to(equal("git@github.com:Mantle/Mantle.git"))
@@ -40,15 +40,15 @@ class RemoteSpec: QuickSpec {
 		describe("==(Remote, Remote)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = repo.mapGitRemote(withName: "upstream") { Remote($0) }
+				let remote1 = repo.withGitRemote(withName: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1).to(equal(remote2))
 			}
 			
 			it("should be false with unequal objcets") {
 				let repo = Fixtures.mantleRepository
-				let origin = repo.mapGitRemote(withName: "origin") { Remote($0) }
-				let upstream = repo.mapGitRemote(withName: "upstream") { Remote($0) }
+				let origin = repo.withGitRemote(withName: "origin") { Remote($0) }
+				let upstream = repo.withGitRemote(withName: "upstream") { Remote($0) }
 				expect(origin).notTo(equal(upstream))
 			}
 		}
@@ -56,7 +56,7 @@ class RemoteSpec: QuickSpec {
 		describe("Remote.hashValue") {
 			it("should be equal with equal objcets") {
 				let repo = Fixtures.mantleRepository
-				let remote1 = repo.mapGitRemote(withName: "upstream") { Remote($0) }
+				let remote1 = repo.withGitRemote(withName: "upstream") { Remote($0) }
 				let remote2 = remote1
 				expect(remote1.hashValue).to(equal(remote2.hashValue))
 			}

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -63,7 +63,7 @@ class RepositorySpec: QuickSpec {
 				expect(cloneResult).to(haveSucceeded())
 
 				if case .success(let clonedRepo) = cloneResult {
-					let remoteResult = clonedRepo.remote(withName: "origin")
+					let remoteResult = clonedRepo.remote(named: "origin")
 					expect(remoteResult).to(haveSucceeded())
 
 					if case .success(let remote) = remoteResult {
@@ -80,7 +80,7 @@ class RepositorySpec: QuickSpec {
 				expect(cloneResult).to(haveSucceeded())
 
 				if case .success(let clonedRepo) = cloneResult {
-					let remoteResult = clonedRepo.remote(withName: "origin")
+					let remoteResult = clonedRepo.remote(named: "origin")
 					expect(remoteResult).to(haveSucceeded())
 
 					if case .success(let remote) = remoteResult {
@@ -104,7 +104,7 @@ class RepositorySpec: QuickSpec {
 					expect(cloneResult).to(haveSucceeded())
 
 					if case .success(let clonedRepo) = cloneResult {
-						let remoteResult = clonedRepo.remote(withName: "origin")
+						let remoteResult = clonedRepo.remote(named: "origin")
 						expect(remoteResult).to(haveSucceeded())
 
 						if case .success(let remote) = remoteResult {
@@ -360,50 +360,50 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.remote(withName:)") {
+		describe("Repository.remote(named:)") {
 			it("should return the remote if it exists") {
 				let repo = Fixtures.mantleRepository
-				let result = repo.remote(withName: "upstream")
+				let result = repo.remote(named: "upstream")
 				expect(result.map { $0.name }).to(haveSucceeded(equal("upstream")))
 			}
 			
 			it("should error if the remote doesn't exist") {
 				let repo = Fixtures.simpleRepository
-				let result = repo.remote(withName: "nonexistent")
+				let result = repo.remote(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.reference(withName:)") {
+		describe("Repository.reference(named:)") {
 			it("should return a local branch if it exists") {
 				let name = "refs/heads/master"
-				let result = Fixtures.simpleRepository.reference(withName: name)
+				let result = Fixtures.simpleRepository.reference(named: name)
 				expect(result.map { $0.longName }).to(haveSucceeded(equal(name)))
 				expect(result.value as? Branch).notTo(beNil())
 			}
 
 			it("should return a remote branch if it exists") {
 				let name = "refs/remotes/upstream/master"
-				let result = Fixtures.mantleRepository.reference(withName: name)
+				let result = Fixtures.mantleRepository.reference(named: name)
 				expect(result.map { $0.longName }).to(haveSucceeded(equal(name)))
 				expect(result.value as? Branch).notTo(beNil())
 			}
 			
 			it("should return a tag if it exists") {
 				let name = "refs/tags/tag-2"
-				let result = Fixtures.simpleRepository.reference(withName: name)
+				let result = Fixtures.simpleRepository.reference(named: name)
 				expect(result.value?.longName).to(equal(name))
 				expect(result.value as? TagReference).notTo(beNil())
 			}
 			
 			it("should return the reference if it exists") {
 				let name = "refs/other-ref"
-				let result = Fixtures.simpleRepository.reference(withName: name)
+				let result = Fixtures.simpleRepository.reference(named: name)
 				expect(result.value?.longName).to(equal(name))
 			}
 			
 			it("should error if the reference doesn't exist") {
-				let result = Fixtures.simpleRepository.reference(withName: "refs/heads/nonexistent")
+				let result = Fixtures.simpleRepository.reference(named: "refs/heads/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -412,9 +412,9 @@ class RepositorySpec: QuickSpec {
 			it("should return all the local branches") {
 				let repo = Fixtures.simpleRepository
 				let expected = [
-					repo.localBranch(withName: "another-branch").value!,
-					repo.localBranch(withName: "master").value!,
-					repo.localBranch(withName: "yet-another-branch").value!,
+					repo.localBranch(named: "another-branch").value!,
+					repo.localBranch(named: "master").value!,
+					repo.localBranch(named: "yet-another-branch").value!,
 				]
 				expect(repo.localBranches().value).to(equal(expected))
 			}
@@ -442,7 +442,7 @@ class RepositorySpec: QuickSpec {
 					"upstream/reversible-transformer",
 					"upstream/subclassing-notes",
 				]
-				let expected = expectedNames.map { repo.remoteBranch(withName: $0).value! }
+				let expected = expectedNames.map { repo.remoteBranch(named: $0).value! }
 				let actual = repo.remoteBranches().value!.sorted {
 					return $0.longName.characters.lexicographicallyPrecedes($1.longName.characters)
 				}
@@ -451,26 +451,26 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.localBranch(withName:)") {
+		describe("Repository.localBranch(named:)") {
 			it("should return the branch if it exists") {
-				let result = Fixtures.simpleRepository.localBranch(withName: "master")
+				let result = Fixtures.simpleRepository.localBranch(named: "master")
 				expect(result.value?.longName).to(equal("refs/heads/master"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.localBranch(withName: "nonexistent")
+				let result = Fixtures.simpleRepository.localBranch(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.remoteBranch(withName:)") {
+		describe("Repository.remoteBranch(named:)") {
 			it("should return the branch if it exists") {
-				let result = Fixtures.mantleRepository.remoteBranch(withName: "upstream/master")
+				let result = Fixtures.mantleRepository.remoteBranch(named: "upstream/master")
 				expect(result.value?.longName).to(equal("refs/remotes/upstream/master"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.remoteBranch(withName: "origin/nonexistent")
+				let result = Fixtures.simpleRepository.remoteBranch(named: "origin/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -479,21 +479,21 @@ class RepositorySpec: QuickSpec {
 			it("should return all the tags") {
 				let repo = Fixtures.simpleRepository
 				let expected = [
-					repo.tag(withName: "tag-1").value!,
-					repo.tag(withName: "tag-2").value!,
+					repo.tag(named: "tag-1").value!,
+					repo.tag(named: "tag-2").value!,
 				]
 				expect(repo.allTags().value).to(equal(expected))
 			}
 		}
 		
-		describe("Repository.tag(withName:)") {
+		describe("Repository.tag(named:)") {
 			it("should return the tag if it exists") {
-				let result = Fixtures.simpleRepository.tag(withName: "tag-2")
+				let result = Fixtures.simpleRepository.tag(named: "tag-2")
 				expect(result.value?.longName).to(equal("refs/tags/tag-2"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.tag(withName: "nonexistent")
+				let result = Fixtures.simpleRepository.tag(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -526,7 +526,7 @@ class RepositorySpec: QuickSpec {
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
 				
-				expect(repo.setHEAD(repo.localBranch(withName: "master").value!)).to(haveSucceeded())
+				expect(repo.setHEAD(repo.localBranch(named: "master").value!)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 			}
 		}
@@ -537,7 +537,7 @@ class RepositorySpec: QuickSpec {
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 				
-				let branch = repo.localBranch(withName: "another-branch").value!
+				let branch = repo.localBranch(named: "another-branch").value!
 				expect(repo.setHEAD(branch)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
 				
@@ -561,7 +561,7 @@ class RepositorySpec: QuickSpec {
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
 
-				expect(repo.checkout(repo.localBranch(withName: "master").value!, strategy: CheckoutStrategy.None)).to(haveSucceeded())
+				expect(repo.checkout(repo.localBranch(named: "master").value!, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 			}
 
@@ -586,7 +586,7 @@ class RepositorySpec: QuickSpec {
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 				
-				let branch = repo.localBranch(withName: "another-branch").value!
+				let branch = repo.localBranch(named: "another-branch").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
 				

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -115,12 +115,12 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.blob(with: )") {
+		describe("Repository.blob(withIdentity: )") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let result = repo.blob(with: oid)
+				let result = repo.blob(withIdentity: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -128,7 +128,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.blob(with: oid)
+				let result = repo.blob(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -137,7 +137,7 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.blob(with: oid)
+				let result = repo.blob(withIdentity: oid)
 				expect(result).to(haveFailed())
 			}
 		}
@@ -147,7 +147,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.commit(with: oid)
+				let result = repo.commit(withIdentity: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -155,7 +155,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.commit(with: oid)
+				let result = repo.commit(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -164,17 +164,17 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.commit(with: oid)
+				let result = repo.commit(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.tag(with: )") {
+		describe("Repository.tag(withIdentity: )") {
 			it("should return the tag if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let result = repo.tag(with: oid)
+				let result = repo.tag(withIdentity: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -182,7 +182,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.tag(with: oid)
+				let result = repo.tag(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -191,7 +191,7 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.tag(with: oid)
+				let result = repo.tag(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -201,7 +201,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.tree(with: oid)
+				let result = repo.tree(withIdentity: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -209,7 +209,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.tree(with: oid)
+				let result = repo.tree(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -218,48 +218,48 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.tree(with: oid)
+				let result = repo.tree(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("\(Repository.object(with:))") {
+		describe("\(Repository.object(withIdentity:))") {
 			it("should work with a blob") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				let blob   = repo.blob(with: oid).value
-				let result = repo.object(with: oid)
+				let blob   = repo.blob(withIdentity: oid).value
+				let result = repo.object(withIdentity: oid)
 				expect(result.map { $0 as! Blob }).to(haveSucceeded(equal(blob)))
 			}
 			
 			it("should work with a commit") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				let commit = repo.commit(with: oid).value
-				let result = repo.object(with: oid)
+				let commit = repo.commit(withIdentity: oid).value
+				let result = repo.object(withIdentity: oid)
 				expect(result.map { $0 as! Commit }).to(haveSucceeded(equal(commit)))
 			}
 			
 			it("should work with a tag") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				let tag    = repo.tag(with: oid).value
-				let result = repo.object(with: oid)
+				let tag    = repo.tag(withIdentity: oid).value
+				let result = repo.object(withIdentity: oid)
 				expect(result.map { $0 as! Tag }).to(haveSucceeded(equal(tag)))
 			}
 			
 			it("should work with a tree") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				let tree   = repo.tree(with: oid).value
-				let result = repo.object(with: oid)
+				let tree   = repo.tree(withIdentity: oid).value
+				let result = repo.object(withIdentity: oid)
 				expect(result.map { $0 as! Tree }).to(haveSucceeded(equal(tree)))
 			}
 			
 			it("should error if there's no object with that oid") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				let result = repo.object(with: oid)
+				let result = repo.object(withIdentity: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -270,7 +270,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = PointerTo<Commit>(oid)
-				let commit = repo.commit(with: oid).value!
+				let commit = repo.commit(withIdentity: oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(commit)))
 			}
 			
@@ -279,7 +279,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = PointerTo<Tree>(oid)
-				let tree = repo.tree(with: oid).value!
+				let tree = repo.tree(withIdentity: oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tree)))
 			}
 			
@@ -288,7 +288,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = PointerTo<Blob>(oid)
-				let blob = repo.blob(with: oid).value!
+				let blob = repo.blob(withIdentity: oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(blob)))
 			}
 			
@@ -297,7 +297,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = PointerTo<Tag>(oid)
-				let tag = repo.tag(with: oid).value!
+				let tag = repo.tag(withIdentity: oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tag)))
 			}
 		}
@@ -308,7 +308,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = Pointer.Commit(oid)
-				let commit = repo.commit(with: oid).value!
+				let commit = repo.commit(withIdentity: oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Commit }
 				expect(result).to(haveSucceeded(equal(commit)))
 			}
@@ -318,7 +318,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = Pointer.Tree(oid)
-				let tree = repo.tree(with: oid).value!
+				let tree = repo.tree(withIdentity: oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tree }
 				expect(result).to(haveSucceeded(equal(tree)))
 			}
@@ -328,7 +328,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = Pointer.Blob(oid)
-				let blob = repo.blob(with: oid).value!
+				let blob = repo.blob(withIdentity: oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Blob }
 				expect(result).to(haveSucceeded(equal(blob)))
 			}
@@ -338,7 +338,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = Pointer.Tag(oid)
-				let tag = repo.tag(with: oid).value!
+				let tag = repo.tag(withIdentity: oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tag }
 				expect(result).to(haveSucceeded(equal(tag)))
 			}

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -14,7 +14,7 @@ import Guanaco
 
 class RepositorySpec: QuickSpec {
 	override func spec() {
-		describe("Repository.Type.atURL()") {
+		describe("Repository.Type.at(_:)") {
 			it("should work if the repo exists") {
 				let repo = Fixtures.simpleRepository
 				expect(repo.directoryURL).notTo(beNil())
@@ -30,7 +30,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 
-		describe("Repository.Type.clone()") {
+		describe("Repository.Type.clone(from:to:)") {
 			it("should handle local clones") {
 				let remoteRepo = Fixtures.simpleRepository
 				let localURL = self.temporaryURL(forPurpose: "local-clone")
@@ -115,7 +115,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.blob(withIdentity: )") {
+		describe("Repository.blob(withIdentity:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
@@ -142,7 +142,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.commitWithOID()") {
+		describe("Repository.commit(withIdentity:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
@@ -169,7 +169,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.tag(withIdentity: )") {
+		describe("Repository.tag(withIdentity:)") {
 			it("should return the tag if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
@@ -196,7 +196,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.treeWithOID()") {
+		describe("Repository.tree(withIdentity:)") {
 			it("should return the tree if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
@@ -223,7 +223,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("\(Repository.object(withIdentity:))") {
+		describe("Repository.object(withIdentity:)") {
 			it("should work with a blob") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
@@ -264,7 +264,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repsoitory.object(from: PointerTo)") {
+		describe("Repository.object(from: PointerTo)") {
 			it("should work with commits") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
@@ -360,7 +360,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.remote(withName: )") {
+		describe("Repository.remote(withName:)") {
 			it("should return the remote if it exists") {
 				let repo = Fixtures.mantleRepository
 				let result = repo.remote(withName: "upstream")
@@ -374,7 +374,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.referenceWithName()") {
+		describe("Repository.reference(withName:)") {
 			it("should return a local branch if it exists") {
 				let name = "refs/heads/master"
 				let result = Fixtures.simpleRepository.reference(withName: name)
@@ -451,7 +451,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.localBranchWithName()") {
+		describe("Repository.localBranch(withName:)") {
 			it("should return the branch if it exists") {
 				let result = Fixtures.simpleRepository.localBranch(withName: "master")
 				expect(result.value?.longName).to(equal("refs/heads/master"))
@@ -463,7 +463,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.remoteBranchWithName()") {
+		describe("Repository.remoteBranch(withName:)") {
 			it("should return the branch if it exists") {
 				let result = Fixtures.mantleRepository.remoteBranch(withName: "upstream/master")
 				expect(result.value?.longName).to(equal("refs/remotes/upstream/master"))
@@ -486,7 +486,7 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.tagWithName()") {
+		describe("Repository.tag(withName:)") {
 			it("should return the tag if it exists") {
 				let result = Fixtures.simpleRepository.tag(withName: "tag-2")
 				expect(result.value?.longName).to(equal("refs/tags/tag-2"))

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -33,7 +33,7 @@ class RepositorySpec: QuickSpec {
 		describe("Repository.Type.clone()") {
 			it("should handle local clones") {
 				let remoteRepo = Fixtures.simpleRepository
-				let localURL = self.temporaryURLForPurpose("local-clone")
+				let localURL = self.temporaryURL(forPurpose: "local-clone")
 				let result = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true)
 
 				expect(result).to(haveSucceeded())
@@ -45,7 +45,7 @@ class RepositorySpec: QuickSpec {
 
 			it("should handle bare clones") {
 				let remoteRepo = Fixtures.simpleRepository
-				let localURL = self.temporaryURLForPurpose("bare-clone")
+				let localURL = self.temporaryURL(forPurpose: "bare-clone")
 				let result = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true, bare: true)
 
 				expect(result).to(haveSucceeded())
@@ -57,7 +57,7 @@ class RepositorySpec: QuickSpec {
 
 			it("should have set a valid remote url") {
 				let remoteRepo = Fixtures.simpleRepository
-				let localURL = self.temporaryURLForPurpose("valid-remote-clone")
+				let localURL = self.temporaryURL(forPurpose: "valid-remote-clone")
 				let cloneResult = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true)
 
 				expect(cloneResult).to(haveSucceeded())
@@ -74,7 +74,7 @@ class RepositorySpec: QuickSpec {
 
 			it("should be able to clone a remote repository") {
 				let remoteRepoURL = URL(string: "https://github.com/libgit2/libgit2.github.com.git")
-				let localURL =  self.temporaryURLForPurpose("public-remote-clone")
+				let localURL =  self.temporaryURL(forPurpose: "public-remote-clone")
 				let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL)
 
 				expect(cloneResult).to(haveSucceeded())
@@ -96,7 +96,7 @@ class RepositorySpec: QuickSpec {
 
 				it("should be able to clone a remote repository requiring credentials") {
 					let remoteRepoURL = URL(string: privateRepo)
-					let localURL =  self.temporaryURLForPurpose("private-remote-clone")
+					let localURL =  self.temporaryURL(forPurpose: "private-remote-clone")
 
 					let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL,
 						credentials: .SSHMemory(username: gitUsername, publicKey: publicKey, privateKey: privateKey, passphrase: passphrase))
@@ -596,7 +596,7 @@ class RepositorySpec: QuickSpec {
 		}
 	}
 
-	func temporaryURLForPurpose(_ purpose: String) -> URL {
+	func temporaryURL(forPurpose purpose: String) -> URL {
 		let globallyUniqueString = ProcessInfo.processInfo.globallyUniqueString
 		let path = "\(NSTemporaryDirectory())\(globallyUniqueString)_\(purpose)"
 		return URL(fileURLWithPath: path)

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -22,7 +22,7 @@ class RepositorySpec: QuickSpec {
 			
 			it("should fail if the repo doesn't exist") {
 				let url = URL(fileURLWithPath: "blah")
-				let result = Repository.atURL(url)
+				let result = Repository.at(url)
 				expect(result).to(haveFailed(beAnError(
 					domain: equal(libGit2ErrorDomain),
 					localizedDescription: match("Failed to resolve path")
@@ -34,7 +34,7 @@ class RepositorySpec: QuickSpec {
 			it("should handle local clones") {
 				let remoteRepo = Fixtures.simpleRepository
 				let localURL = self.temporaryURLForPurpose("local-clone")
-				let result = Repository.cloneFromURL(remoteRepo.directoryURL!, toURL: localURL, localClone: true)
+				let result = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true)
 
 				expect(result).to(haveSucceeded())
 
@@ -46,7 +46,7 @@ class RepositorySpec: QuickSpec {
 			it("should handle bare clones") {
 				let remoteRepo = Fixtures.simpleRepository
 				let localURL = self.temporaryURLForPurpose("bare-clone")
-				let result = Repository.cloneFromURL(remoteRepo.directoryURL!, toURL: localURL, localClone: true, bare: true)
+				let result = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true, bare: true)
 
 				expect(result).to(haveSucceeded())
 
@@ -58,12 +58,12 @@ class RepositorySpec: QuickSpec {
 			it("should have set a valid remote url") {
 				let remoteRepo = Fixtures.simpleRepository
 				let localURL = self.temporaryURLForPurpose("valid-remote-clone")
-				let cloneResult = Repository.cloneFromURL(remoteRepo.directoryURL!, toURL: localURL, localClone: true)
+				let cloneResult = Repository.clone(from: remoteRepo.directoryURL!, to: localURL, localClone: true)
 
 				expect(cloneResult).to(haveSucceeded())
 
 				if case .success(let clonedRepo) = cloneResult {
-					let remoteResult = clonedRepo.remoteWithName("origin")
+					let remoteResult = clonedRepo.remote(withName: "origin")
 					expect(remoteResult).to(haveSucceeded())
 
 					if case .success(let remote) = remoteResult {
@@ -75,12 +75,12 @@ class RepositorySpec: QuickSpec {
 			it("should be able to clone a remote repository") {
 				let remoteRepoURL = URL(string: "https://github.com/libgit2/libgit2.github.com.git")
 				let localURL =  self.temporaryURLForPurpose("public-remote-clone")
-				let cloneResult = Repository.cloneFromURL(remoteRepoURL!, toURL: localURL)
+				let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL)
 
 				expect(cloneResult).to(haveSucceeded())
 
 				if case .success(let clonedRepo) = cloneResult {
-					let remoteResult = clonedRepo.remoteWithName("origin")
+					let remoteResult = clonedRepo.remote(withName: "origin")
 					expect(remoteResult).to(haveSucceeded())
 
 					if case .success(let remote) = remoteResult {
@@ -98,13 +98,13 @@ class RepositorySpec: QuickSpec {
 					let remoteRepoURL = URL(string: privateRepo)
 					let localURL =  self.temporaryURLForPurpose("private-remote-clone")
 
-					let cloneResult = Repository.cloneFromURL(remoteRepoURL!, toURL: localURL,
+					let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL,
 						credentials: .SSHMemory(username: gitUsername, publicKey: publicKey, privateKey: privateKey, passphrase: passphrase))
 
 					expect(cloneResult).to(haveSucceeded())
 
 					if case .success(let clonedRepo) = cloneResult {
-						let remoteResult = clonedRepo.remoteWithName("origin")
+						let remoteResult = clonedRepo.remote(withName: "origin")
 						expect(remoteResult).to(haveSucceeded())
 
 						if case .success(let remote) = remoteResult {
@@ -115,12 +115,12 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.blobWithOID()") {
+		describe("Repository.blob(with: )") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let result = repo.blobWithOID(oid)
+				let result = repo.blob(with: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -128,7 +128,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.blobWithOID(oid)
+				let result = repo.blob(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -137,7 +137,7 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.blobWithOID(oid)
+				let result = repo.blob(with: oid)
 				expect(result).to(haveFailed())
 			}
 		}
@@ -147,7 +147,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.commitWithOID(oid)
+				let result = repo.commit(with: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -155,7 +155,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.commitWithOID(oid)
+				let result = repo.commit(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -164,17 +164,17 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.commitWithOID(oid)
+				let result = repo.commit(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.tagWithOID()") {
+		describe("Repository.tag(with: )") {
 			it("should return the tag if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let result = repo.tagWithOID(oid)
+				let result = repo.tag(with: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -182,7 +182,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.tagWithOID(oid)
+				let result = repo.tag(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -191,7 +191,7 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.tagWithOID(oid)
+				let result = repo.tag(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -201,7 +201,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.treeWithOID(oid)
+				let result = repo.tree(with: oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -209,7 +209,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.treeWithOID(oid)
+				let result = repo.tree(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -218,60 +218,60 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.treeWithOID(oid)
+				let result = repo.tree(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.objectWithOID()") {
+		describe("\(Repository.object(with:))") {
 			it("should work with a blob") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				let blob   = repo.blobWithOID(oid).value
-				let result = repo.objectWithOID(oid)
+				let blob   = repo.blob(with: oid).value
+				let result = repo.object(with: oid)
 				expect(result.map { $0 as! Blob }).to(haveSucceeded(equal(blob)))
 			}
 			
 			it("should work with a commit") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				let commit = repo.commitWithOID(oid).value
-				let result = repo.objectWithOID(oid)
+				let commit = repo.commit(with: oid).value
+				let result = repo.object(with: oid)
 				expect(result.map { $0 as! Commit }).to(haveSucceeded(equal(commit)))
 			}
 			
 			it("should work with a tag") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				let tag    = repo.tagWithOID(oid).value
-				let result = repo.objectWithOID(oid)
+				let tag    = repo.tag(with: oid).value
+				let result = repo.object(with: oid)
 				expect(result.map { $0 as! Tag }).to(haveSucceeded(equal(tag)))
 			}
 			
 			it("should work with a tree") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				let tree   = repo.treeWithOID(oid).value
-				let result = repo.objectWithOID(oid)
+				let tree   = repo.tree(with: oid).value
+				let result = repo.object(with: oid)
 				expect(result.map { $0 as! Tree }).to(haveSucceeded(equal(tree)))
 			}
 			
 			it("should error if there's no object with that oid") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				let result = repo.objectWithOID(oid)
+				let result = repo.object(with: oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repsoitory.objectFromPointer(PointerTo)") {
+		describe("Repsoitory.object(from: PointerTo)") {
 			it("should work with commits") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = PointerTo<Commit>(oid)
-				let commit = repo.commitWithOID(oid).value!
-				expect(repo.objectFromPointer(pointer)).to(haveSucceeded(equal(commit)))
+				let commit = repo.commit(with: oid).value!
+				expect(repo.object(from: pointer)).to(haveSucceeded(equal(commit)))
 			}
 			
 			it("should work with trees") {
@@ -279,8 +279,8 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = PointerTo<Tree>(oid)
-				let tree = repo.treeWithOID(oid).value!
-				expect(repo.objectFromPointer(pointer)).to(haveSucceeded(equal(tree)))
+				let tree = repo.tree(with: oid).value!
+				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tree)))
 			}
 			
 			it("should work with blobs") {
@@ -288,8 +288,8 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = PointerTo<Blob>(oid)
-				let blob = repo.blobWithOID(oid).value!
-				expect(repo.objectFromPointer(pointer)).to(haveSucceeded(equal(blob)))
+				let blob = repo.blob(with: oid).value!
+				expect(repo.object(from: pointer)).to(haveSucceeded(equal(blob)))
 			}
 			
 			it("should work with tags") {
@@ -297,19 +297,19 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = PointerTo<Tag>(oid)
-				let tag = repo.tagWithOID(oid).value!
-				expect(repo.objectFromPointer(pointer)).to(haveSucceeded(equal(tag)))
+				let tag = repo.tag(with: oid).value!
+				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tag)))
 			}
 		}
 		
-		describe("Repository.objectFromPointer(Pointer)") {
+		describe("Repository.object(from: Pointer)") {
 			it("should work with commits") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = Pointer.Commit(oid)
-				let commit = repo.commitWithOID(oid).value!
-				let result = repo.objectFromPointer(pointer).map { $0 as! Commit }
+				let commit = repo.commit(with: oid).value!
+				let result = repo.object(from: pointer).map { $0 as! Commit }
 				expect(result).to(haveSucceeded(equal(commit)))
 			}
 			
@@ -318,8 +318,8 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = Pointer.Tree(oid)
-				let tree = repo.treeWithOID(oid).value!
-				let result = repo.objectFromPointer(pointer).map { $0 as! Tree }
+				let tree = repo.tree(with: oid).value!
+				let result = repo.object(from: pointer).map { $0 as! Tree }
 				expect(result).to(haveSucceeded(equal(tree)))
 			}
 			
@@ -328,8 +328,8 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = Pointer.Blob(oid)
-				let blob = repo.blobWithOID(oid).value!
-				let result = repo.objectFromPointer(pointer).map { $0 as! Blob }
+				let blob = repo.blob(with: oid).value!
+				let result = repo.object(from: pointer).map { $0 as! Blob }
 				expect(result).to(haveSucceeded(equal(blob)))
 			}
 			
@@ -338,8 +338,8 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = Pointer.Tag(oid)
-				let tag = repo.tagWithOID(oid).value!
-				let result = repo.objectFromPointer(pointer).map { $0 as! Tag }
+				let tag = repo.tag(with: oid).value!
+				let result = repo.object(from: pointer).map { $0 as! Tag }
 				expect(result).to(haveSucceeded(equal(tag)))
 			}
 		}
@@ -360,16 +360,16 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.remoteWithName()") {
+		describe("Repository.remote(withName: )") {
 			it("should return the remote if it exists") {
 				let repo = Fixtures.mantleRepository
-				let result = repo.remoteWithName("upstream")
+				let result = repo.remote(withName: "upstream")
 				expect(result.map { $0.name }).to(haveSucceeded(equal("upstream")))
 			}
 			
 			it("should error if the remote doesn't exist") {
 				let repo = Fixtures.simpleRepository
-				let result = repo.remoteWithName("nonexistent")
+				let result = repo.remote(withName: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -377,33 +377,33 @@ class RepositorySpec: QuickSpec {
 		describe("Repository.referenceWithName()") {
 			it("should return a local branch if it exists") {
 				let name = "refs/heads/master"
-				let result = Fixtures.simpleRepository.referenceWithName(name)
+				let result = Fixtures.simpleRepository.reference(withName: name)
 				expect(result.map { $0.longName }).to(haveSucceeded(equal(name)))
 				expect(result.value as? Branch).notTo(beNil())
 			}
 
 			it("should return a remote branch if it exists") {
 				let name = "refs/remotes/upstream/master"
-				let result = Fixtures.mantleRepository.referenceWithName(name)
+				let result = Fixtures.mantleRepository.reference(withName: name)
 				expect(result.map { $0.longName }).to(haveSucceeded(equal(name)))
 				expect(result.value as? Branch).notTo(beNil())
 			}
 			
 			it("should return a tag if it exists") {
 				let name = "refs/tags/tag-2"
-				let result = Fixtures.simpleRepository.referenceWithName(name)
+				let result = Fixtures.simpleRepository.reference(withName: name)
 				expect(result.value?.longName).to(equal(name))
 				expect(result.value as? TagReference).notTo(beNil())
 			}
 			
 			it("should return the reference if it exists") {
 				let name = "refs/other-ref"
-				let result = Fixtures.simpleRepository.referenceWithName(name)
+				let result = Fixtures.simpleRepository.reference(withName: name)
 				expect(result.value?.longName).to(equal(name))
 			}
 			
 			it("should error if the reference doesn't exist") {
-				let result = Fixtures.simpleRepository.referenceWithName("refs/heads/nonexistent")
+				let result = Fixtures.simpleRepository.reference(withName: "refs/heads/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -412,9 +412,9 @@ class RepositorySpec: QuickSpec {
 			it("should return all the local branches") {
 				let repo = Fixtures.simpleRepository
 				let expected = [
-					repo.localBranchWithName("another-branch").value!,
-					repo.localBranchWithName("master").value!,
-					repo.localBranchWithName("yet-another-branch").value!,
+					repo.localBranch(withName: "another-branch").value!,
+					repo.localBranch(withName: "master").value!,
+					repo.localBranch(withName: "yet-another-branch").value!,
 				]
 				expect(repo.localBranches().value).to(equal(expected))
 			}
@@ -442,7 +442,7 @@ class RepositorySpec: QuickSpec {
 					"upstream/reversible-transformer",
 					"upstream/subclassing-notes",
 				]
-				let expected = expectedNames.map { repo.remoteBranchWithName($0).value! }
+				let expected = expectedNames.map { repo.remoteBranch(withName: $0).value! }
 				let actual = repo.remoteBranches().value!.sorted {
 					return $0.longName.characters.lexicographicallyPrecedes($1.longName.characters)
 				}
@@ -453,24 +453,24 @@ class RepositorySpec: QuickSpec {
 		
 		describe("Repository.localBranchWithName()") {
 			it("should return the branch if it exists") {
-				let result = Fixtures.simpleRepository.localBranchWithName("master")
+				let result = Fixtures.simpleRepository.localBranch(withName: "master")
 				expect(result.value?.longName).to(equal("refs/heads/master"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.localBranchWithName("nonexistent")
+				let result = Fixtures.simpleRepository.localBranch(withName: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
 		describe("Repository.remoteBranchWithName()") {
 			it("should return the branch if it exists") {
-				let result = Fixtures.mantleRepository.remoteBranchWithName("upstream/master")
+				let result = Fixtures.mantleRepository.remoteBranch(withName: "upstream/master")
 				expect(result.value?.longName).to(equal("refs/remotes/upstream/master"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.remoteBranchWithName("origin/nonexistent")
+				let result = Fixtures.simpleRepository.remoteBranch(withName: "origin/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -479,8 +479,8 @@ class RepositorySpec: QuickSpec {
 			it("should return all the tags") {
 				let repo = Fixtures.simpleRepository
 				let expected = [
-					repo.tagWithName("tag-1").value!,
-					repo.tagWithName("tag-2").value!,
+					repo.tag(withName: "tag-1").value!,
+					repo.tag(withName: "tag-2").value!,
 				]
 				expect(repo.allTags().value).to(equal(expected))
 			}
@@ -488,12 +488,12 @@ class RepositorySpec: QuickSpec {
 		
 		describe("Repository.tagWithName()") {
 			it("should return the tag if it exists") {
-				let result = Fixtures.simpleRepository.tagWithName("tag-2")
+				let result = Fixtures.simpleRepository.tag(withName: "tag-2")
 				expect(result.value?.longName).to(equal("refs/tags/tag-2"))
 			}
 			
 			it("should error if the branch doesn't exists") {
-				let result = Fixtures.simpleRepository.tagWithName("nonexistent")
+				let result = Fixtures.simpleRepository.tag(withName: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -526,7 +526,7 @@ class RepositorySpec: QuickSpec {
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
 				
-				expect(repo.setHEAD(repo.localBranchWithName("master").value!)).to(haveSucceeded())
+				expect(repo.setHEAD(repo.localBranch(withName: "master").value!)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 			}
 		}
@@ -537,7 +537,7 @@ class RepositorySpec: QuickSpec {
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 				
-				let branch = repo.localBranchWithName("another-branch").value!
+				let branch = repo.localBranch(withName: "another-branch").value!
 				expect(repo.setHEAD(branch)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
 				
@@ -561,7 +561,7 @@ class RepositorySpec: QuickSpec {
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
 
-				expect(repo.checkout(repo.localBranchWithName("master").value!, strategy: CheckoutStrategy.None)).to(haveSucceeded())
+				expect(repo.checkout(repo.localBranch(withName: "master").value!, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 			}
 
@@ -586,7 +586,7 @@ class RepositorySpec: QuickSpec {
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 				
-				let branch = repo.localBranchWithName("another-branch").value!
+				let branch = repo.localBranch(withName: "another-branch").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
 				

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -115,12 +115,12 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 		
-		describe("Repository.blob(withIdentity:)") {
+		describe("Repository.blob(_:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
-				let result = repo.blob(withIdentity: oid)
+				let result = repo.blob(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -128,7 +128,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.blob(withIdentity: oid)
+				let result = repo.blob(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -137,17 +137,17 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.blob(withIdentity: oid)
+				let result = repo.blob(oid)
 				expect(result).to(haveFailed())
 			}
 		}
 		
-		describe("Repository.commit(withIdentity:)") {
+		describe("Repository.commit(_:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.commit(withIdentity: oid)
+				let result = repo.commit(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -155,7 +155,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.commit(withIdentity: oid)
+				let result = repo.commit(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -164,17 +164,17 @@ class RepositorySpec: QuickSpec {
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.commit(withIdentity: oid)
+				let result = repo.commit(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.tag(withIdentity:)") {
+		describe("Repository.tag(_:)") {
 			it("should return the tag if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
-				let result = repo.tag(withIdentity: oid)
+				let result = repo.tag(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -182,7 +182,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.tag(withIdentity: oid)
+				let result = repo.tag(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -191,17 +191,17 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.tag(withIdentity: oid)
+				let result = repo.tag(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.tree(withIdentity:)") {
+		describe("Repository.tree(_:)") {
 			it("should return the tree if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
-				let result = repo.tree(withIdentity: oid)
+				let result = repo.tree(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
 			
@@ -209,7 +209,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
 				
-				let result = repo.tree(withIdentity: oid)
+				let result = repo.tree(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 			
@@ -218,48 +218,48 @@ class RepositorySpec: QuickSpec {
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
-				let result = repo.tree(withIdentity: oid)
+				let result = repo.tree(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
 		
-		describe("Repository.object(withIdentity:)") {
+		describe("Repository.object(_:)") {
 			it("should work with a blob") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				let blob   = repo.blob(withIdentity: oid).value
-				let result = repo.object(withIdentity: oid)
+				let blob   = repo.blob(oid).value
+				let result = repo.object(oid)
 				expect(result.map { $0 as! Blob }).to(haveSucceeded(equal(blob)))
 			}
 			
 			it("should work with a commit") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				let commit = repo.commit(withIdentity: oid).value
-				let result = repo.object(withIdentity: oid)
+				let commit = repo.commit(oid).value
+				let result = repo.object(oid)
 				expect(result.map { $0 as! Commit }).to(haveSucceeded(equal(commit)))
 			}
 			
 			it("should work with a tag") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				let tag    = repo.tag(withIdentity: oid).value
-				let result = repo.object(withIdentity: oid)
+				let tag    = repo.tag(oid).value
+				let result = repo.object(oid)
 				expect(result.map { $0 as! Tag }).to(haveSucceeded(equal(tag)))
 			}
 			
 			it("should work with a tree") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				let tree   = repo.tree(withIdentity: oid).value
-				let result = repo.object(withIdentity: oid)
+				let tree   = repo.tree(oid).value
+				let result = repo.object(oid)
 				expect(result.map { $0 as! Tree }).to(haveSucceeded(equal(tree)))
 			}
 			
 			it("should error if there's no object with that oid") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				let result = repo.object(withIdentity: oid)
+				let result = repo.object(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
@@ -270,7 +270,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = PointerTo<Commit>(oid)
-				let commit = repo.commit(withIdentity: oid).value!
+				let commit = repo.commit(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(commit)))
 			}
 			
@@ -279,7 +279,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = PointerTo<Tree>(oid)
-				let tree = repo.tree(withIdentity: oid).value!
+				let tree = repo.tree(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tree)))
 			}
 			
@@ -288,7 +288,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = PointerTo<Blob>(oid)
-				let blob = repo.blob(withIdentity: oid).value!
+				let blob = repo.blob(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(blob)))
 			}
 			
@@ -297,7 +297,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = PointerTo<Tag>(oid)
-				let tag = repo.tag(withIdentity: oid).value!
+				let tag = repo.tag(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tag)))
 			}
 		}
@@ -308,7 +308,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				
 				let pointer = Pointer.Commit(oid)
-				let commit = repo.commit(withIdentity: oid).value!
+				let commit = repo.commit(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Commit }
 				expect(result).to(haveSucceeded(equal(commit)))
 			}
@@ -318,7 +318,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
 				
 				let pointer = Pointer.Tree(oid)
-				let tree = repo.tree(withIdentity: oid).value!
+				let tree = repo.tree(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tree }
 				expect(result).to(haveSucceeded(equal(tree)))
 			}
@@ -328,7 +328,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				
 				let pointer = Pointer.Blob(oid)
-				let blob = repo.blob(withIdentity: oid).value!
+				let blob = repo.blob(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Blob }
 				expect(result).to(haveSucceeded(equal(blob)))
 			}
@@ -338,7 +338,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				
 				let pointer = Pointer.Tag(oid)
-				let tag = repo.tag(withIdentity: oid).value!
+				let tag = repo.tag(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tag }
 				expect(result).to(haveSucceeded(equal(tag)))
 			}


### PR DESCRIPTION
Update SwiftGit2 to follow the Swift 3 [API design guidelines](https://swift.org/documentation/api-design-guidelines/).

Simplified API diffs are below:

## SwiftGit2.framework

`SwiftGit2/CheckoutStrategy.swift`
``` diff
 struct CheckoutStrategy : OptionSet {
-  var git_checkout_strategy: git_checkout_strategy_t
+  var gitCheckoutStrategy: git_checkout_strategy_t
 }
```

`SwiftGit2/Repository.swift`
``` diff
 final class Repository {
-  final class func atURL(_ url: URL) -> Result<Repository, NSError>
+  final class func at(_ url: URL) -> Result<Repository, NSError>

-  final class func cloneFromURL(_ remoteURL: URL, toURL: URL, localClone: Bool = default, bare: Bool = default, credentials: Credentials = default, checkoutStrategy: CheckoutStrategy = default, checkoutProgress: CheckoutProgressBlock? = default) -> Result<Repository, NSError>
+  final class func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = default, bare: Bool = default, credentials: Credentials = default, checkoutStrategy: CheckoutStrategy = default, checkoutProgress: CheckoutProgressBlock? = default) -> Result<Repository, NSError>

-  final func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError>
+  final func withGitObject<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError>

-  final func withLibgit2Object<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError>
+  final func withGitObject<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> T) -> Result<T, NSError>

-  final func objectWithOID(_ oid: OID) -> Result<ObjectType, NSError>
+  final func object(_ oid: OID) -> Result<ObjectType, NSError>

-  final func blobWithOID(_ oid: OID) -> Result<Blob, NSError>
+  final func blob(_ oid: OID) -> Result<Blob, NSError>

-  final func commitWithOID(_ oid: OID) -> Result<Commit, NSError>
+  final func commit(_ oid: OID) -> Result<Commit, NSError>

-  final func tagWithOID(_ oid: OID) -> Result<Tag, NSError>
+  final func tag(_ oid: OID) -> Result<Tag, NSError>

-  final func treeWithOID(_ oid: OID) -> Result<Tree, NSError>
+  final func tree(_ oid: OID) -> Result<Tree, NSError>

-  final func objectFromPointer<T>(_ pointer: PointerTo<T>) -> Result<T, NSError>
+  final func object<T>(from pointer: PointerTo<T>) -> Result<T, NSError>

-  final func objectFromPointer(_ pointer: Pointer) -> Result<ObjectType, NSError>
+  final func object(from pointer: Pointer) -> Result<ObjectType, NSError>

-  final func remoteWithName(_ name: String) -> Result<Remote, NSError>
+  final func remote(named name: String) -> Result<Remote, NSError>

-  final func referencesWithPrefix(_ prefix: String) -> Result<[ReferenceType], NSError>
+  final func references(withPrefix prefix: String) -> Result<[ReferenceType], NSError>

-  final func referenceWithName(_ name: String) -> Result<ReferenceType, NSError>
+  final func reference(named name: String) -> Result<ReferenceType, NSError>

-  final func localBranchWithName(_ name: String) -> Result<Branch, NSError>
+  final func localBranch(named name: String) -> Result<Branch, NSError>

-  final func remoteBranchWithName(_ name: String) -> Result<Branch, NSError>
+  final func remoteBranch(named name: String) -> Result<Branch, NSError>

-  final func tagWithName(_ name: String) -> Result<TagReference, NSError>
+  final func tag(named name: String) -> Result<TagReference, NSError>
 }

-func checkoutProgressCallback(path: UnsafePointer<Int8>?, completed_steps: Int, total_steps: Int, payload: UnsafeMutableRawPointer?)
+func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps: Int, totalSteps: Int, payload: UnsafeMutableRawPointer?)
```

`SwiftGit2/Errors.swift`
``` diff
-func libGit2Error(_ errorCode: Int32, libGit2PointOfFailure: String? = default) -> NSError
+extension NSError {
+  @objc dynamic convenience init(gitError errorCode: Int32, pointOfFailure: String? = default)
+}
```

`SwiftGit2/Libgit2.swift`
``` diff
 extension git_strarray {
-  func filter(f: (String) -> Bool) -> [String]
+  func filter(_ isIncluded: (String) -> Bool) -> [String]

-  func map<T>(f: (String) -> T) -> [T]
+  func map<T>(_ transform: (String) -> T) -> [T]
 }
```

## SwiftGit2Tests.xctest

`SwiftGit2Tests/Fixtures/Fixtures.swift`
``` diff
 final class Fixtures {
-  final func repositoryWithName(_ name: String) -> Repository
+  final func repository(named name: String) -> Repository
 }
```

`SwiftGit2Tests/ObjectsSpec.swift`
``` diff
-func from_git_object<T>(_ repository: Repository, oid: OID, f: (OpaquePointer) -> T) -> T
+extension Repository {
+  final func withGitObject<T>(_ oid: OID, transform: (OpaquePointer) -> T) -> T
+}
```

`SwiftGit2Tests/ReferencesSpec.swift`
``` diff
-func from_git_reference<T>(_ repository: Repository, name: String, f: (OpaquePointer) -> T) -> T
+extension Repository {
+  final func withGitReference<T>(named name: String, transform: (OpaquePointer) -> T) -> T
+}
```

`SwiftGit2Tests/RemotesSpec.swift`
``` diff
-func with_git_remote<T>(_ repository: Repository, name: String, f: (OpaquePointer) -> T) -> T
+extension Repository {
+  final func withGitRemote<T>(named name: String, transform: (OpaquePointer) -> T) -> T
+}
```

`SwiftGit2Tests/RepositorySpec.swift`
``` diff
 @objc class RepositorySpec : QuickSpec {
-  @objc func temporaryURLForPurpose(_ purpose: String) -> URL
+  @objc func temporaryURL(forPurpose purpose: String) -> URL
 }
```
