### PR TITLE
Remove trailing whitespace on blank lines

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,4 +25,4 @@ trailing_comma:
 
 trailing_whitespace:
   ignores_comments: false
-  ignores_empty_lines: true
+  ignores_empty_lines: false

--- a/SwiftGit2/CheckoutStrategy.swift
+++ b/SwiftGit2/CheckoutStrategy.swift
@@ -12,47 +12,47 @@ import libgit2
 /// More detail is available in the libgit2 documentation for `git_checkout_strategy_t`.
 public struct CheckoutStrategy: OptionSet {
 	private let value: UInt
-	
+
 	// MARK: - Initialization
-	
+
 	/// Create an instance initialized with `nil`.
 	public init(nilLiteral: ()) {
 		self.value = 0
 	}
-	
+
 	public init(rawValue value: UInt) {
 		self.value = value
 	}
-	
+
 	public init(_ strategy: git_checkout_strategy_t) {
 		self.value = UInt(strategy.rawValue)
 	}
-	
+
 	public static var allZeros: CheckoutStrategy {
 		return self.init(rawValue: 0)
 	}
-	
+
 	// MARK: - Properties
-	
+
 	public var rawValue: UInt {
 		return value
 	}
-	
+
 	public var gitCheckoutStrategy: git_checkout_strategy_t {
 		return git_checkout_strategy_t(UInt32(self.value))
 	}
-	
+
 	// MARK: - Values
-	
+
 	/// Default is a dry run, no actual updates.
 	public static let None = CheckoutStrategy(GIT_CHECKOUT_NONE)
-	
+
 	/// Allow safe updates that cannot overwrite uncommitted data.
 	public static let Safe = CheckoutStrategy(GIT_CHECKOUT_SAFE)
-	
+
 	/// Allow all updates to force working directory to look like index
 	public static let Force = CheckoutStrategy(GIT_CHECKOUT_FORCE)
-	
+
 	/// Allow checkout to recreate missing files.
 	public static let RecreateMissing = CheckoutStrategy(GIT_CHECKOUT_RECREATE_MISSING)
 
@@ -77,10 +77,10 @@ public struct CheckoutStrategy: OptionSet {
 
 	/// Allow checkout to skip unmerged files
 	public static let SkipUnmerged = CheckoutStrategy(GIT_CHECKOUT_SKIP_UNMERGED)
-	
+
 	/// For unmerged files, checkout stage 2 from index
 	public static let UseOurs = CheckoutStrategy(GIT_CHECKOUT_USE_OURS)
-	
+
 	/// For unmerged files, checkout stage 3 from index
 	public static let UseTheirs = CheckoutStrategy(GIT_CHECKOUT_USE_THEIRS)
 

--- a/SwiftGit2/Libgit2.swift
+++ b/SwiftGit2/Libgit2.swift
@@ -16,7 +16,7 @@ extension git_strarray {
 	func filter(_ isIncluded: (String) -> Bool) -> [String] {
 		return map { $0 }.filter(isIncluded)
 	}
-	
+
 	func map<T>(_ transform: (String) -> T) -> [T] {
 		return (0..<self.count).map {
 			let string = String(validatingUTF8: self.strings[$0]!)!

--- a/SwiftGit2/OID.swift
+++ b/SwiftGit2/OID.swift
@@ -11,9 +11,9 @@ import libgit2
 
 /// An identifier for a Git object.
 public struct OID {
-	
+
 	// MARK: - Initializers
-	
+
 	/// Create an instance from a hex formatted string.
 	///
 	/// string - A 40-byte hex formatted string.
@@ -22,26 +22,26 @@ public struct OID {
 		if string.lengthOfBytes(using: String.Encoding.ascii) > 40 {
 			return nil
 		}
-		
+
 		let pointer = UnsafeMutablePointer<git_oid>.allocate(capacity: 1)
 		let result = git_oid_fromstr(pointer, string)
-		
+
 		if result < GIT_OK.rawValue {
 			pointer.deallocate(capacity: 1)
 			return nil
 		}
-		
+
 		oid = pointer.pointee
 		pointer.deallocate(capacity: 1)
 	}
-	
+
 	/// Create an instance from a libgit2 `git_oid`.
 	public init(_ oid: git_oid) {
 		self.oid = oid
 	}
-	
+
 	// MARK: - Properties
-	
+
 	public let oid: git_oid
 }
 
@@ -51,7 +51,7 @@ extension OID: CustomStringConvertible {
 		let string = UnsafeMutablePointer<Int8>.allocate(capacity: length)
 		var oid = self.oid
 		git_oid_fmt(string, &oid)
-		
+
 		return String(bytesNoCopy: string, length: length, encoding: .ascii, freeWhenDone: true)!
 	}
 }

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -12,10 +12,10 @@ import libgit2
 /// A git object.
 public protocol ObjectType {
 	static var type: git_otype { get }
-	
+
 	/// The OID of the object.
 	var oid: OID { get }
-	
+
 	/// Create an instance with the underlying libgit2 type.
 	init(_ pointer: OpaquePointer)
 }
@@ -27,16 +27,16 @@ public func == <O: ObjectType>(lhs: O, rhs: O) -> Bool {
 public struct Signature {
 	/// The name of the person.
 	public let name: String
-	
+
 	/// The email of the person.
 	public let email: String
-	
+
 	/// The time when the action happened.
 	public let time: Date
-	
+
 	/// The time zone that `time` should be interpreted relative to.
 	public let timeZone: TimeZone
-	
+
 	/// Create an instance with a libgit2 `git_signature`.
 	public init(_ signature: git_signature) {
 		name = String(validatingUTF8: signature.name)!
@@ -62,25 +62,25 @@ public func == (lhs: Signature, rhs: Signature) -> Bool {
 /// A git commit.
 public struct Commit: ObjectType {
 	public static let type = GIT_OBJ_COMMIT
-	
+
 	/// The OID of the commit.
 	public let oid: OID
-	
+
 	/// The OID of the commit's tree.
 	public let tree: PointerTo<Tree>
-	
+
 	/// The OIDs of the commit's parents.
 	public let parents: [PointerTo<Commit>]
-	
+
 	/// The author of the commit.
 	public let author: Signature
-	
+
 	/// The committer of the commit.
 	public let committer: Signature
-	
+
 	/// The full message of the commit.
 	public let message: String
-	
+
 	/// Create an instance with a libgit2 `git_commit` object.
 	public init(_ pointer: OpaquePointer) {
 		oid = OID(git_object_id(pointer).pointee)
@@ -88,7 +88,7 @@ public struct Commit: ObjectType {
 		author = Signature(git_commit_author(pointer).pointee)
 		committer = Signature(git_commit_committer(pointer).pointee)
 		tree = PointerTo(OID(git_commit_tree_id(pointer).pointee))
-		
+
 		self.parents = (0..<git_commit_parentcount(pointer)).map {
 			return PointerTo(OID(git_commit_parent_id(pointer, $0).pointee))
 		}
@@ -104,18 +104,18 @@ extension Commit: Hashable {
 /// A git tree.
 public struct Tree: ObjectType {
 	public static let type = GIT_OBJ_TREE
-	
+
 	/// An entry in a `Tree`.
 	public struct Entry {
 		/// The entry's UNIX file attributes.
 		public let attributes: Int32
-		
+
 		/// The object pointed to by the entry.
 		public let object: Pointer
-		
+
 		/// The file name of the entry.
 		public let name: String
-		
+
 		/// Create an instance with a libgit2 `git_tree_entry`.
 		public init(_ pointer: OpaquePointer) {
 			let oid = OID(git_tree_entry_id(pointer).pointee)
@@ -123,7 +123,7 @@ public struct Tree: ObjectType {
 			object = Pointer(oid: oid, type: git_tree_entry_type(pointer))!
 			name = String(validatingUTF8: git_tree_entry_name(pointer))!
 		}
-		
+
 		/// Create an instance with the individual values.
 		public init(attributes: Int32, object: Pointer, name: String) {
 			self.attributes = attributes
@@ -134,14 +134,14 @@ public struct Tree: ObjectType {
 
 	/// The OID of the tree.
 	public let oid: OID
-	
+
 	/// The entries in the tree.
 	public let entries: [String: Entry]
-	
+
 	/// Create an instance with a libgit2 `git_tree`.
 	public init(_ pointer: OpaquePointer) {
 		oid = OID(git_object_id(pointer).pointee)
-		
+
 		var entries: [String: Entry] = [:]
 		for idx in 0..<git_tree_entrycount(pointer) {
 			let entry = Entry(git_tree_entry_byindex(pointer, idx)!)
@@ -178,17 +178,17 @@ extension Tree: Hashable {
 /// A git blob.
 public struct Blob: ObjectType {
 	public static let type = GIT_OBJ_BLOB
-	
+
 	/// The OID of the blob.
 	public let oid: OID
-	
+
 	/// The contents of the blob.
 	public let data: Data
-	
+
 	/// Create an instance with a libgit2 `git_blob`.
 	public init(_ pointer: OpaquePointer) {
 		oid = OID(git_object_id(pointer).pointee)
-		
+
 		let length = Int(git_blob_rawsize(pointer))
 		data = Data(bytes: git_blob_rawcontent(pointer), count: length)
 	}
@@ -203,22 +203,22 @@ extension Blob: Hashable {
 /// An annotated git tag.
 public struct Tag: ObjectType {
 	public static let type = GIT_OBJ_TAG
-	
+
 	/// The OID of the tag.
 	public let oid: OID
-	
+
 	/// The tagged object.
 	public let target: Pointer
-	
+
 	/// The name of the tag.
 	public let name: String
-	
+
 	/// The tagger (author) of the tag.
 	public let tagger: Signature
-	
+
 	/// The message of the tag.
 	public let message: String
-	
+
 	/// Create an instance with a libgit2 `git_tag`.
 	public init(_ pointer: OpaquePointer) {
 		oid = OID(git_object_id(pointer).pointee)

--- a/SwiftGit2/Pointers.swift
+++ b/SwiftGit2/Pointers.swift
@@ -12,7 +12,7 @@ import libgit2
 public protocol PointerType: Equatable, Hashable {
 	/// The OID of the referenced object.
 	var oid: OID { get }
-	
+
 	/// The libgit2 `git_otype` of the referenced object.
 	var type: git_otype { get }
 }
@@ -27,7 +27,7 @@ public enum Pointer: PointerType {
 	case Tree(OID)
 	case Blob(OID)
 	case Tag(OID)
-	
+
 	public var oid: OID {
 		switch self {
 		case let .Commit(oid):
@@ -40,7 +40,7 @@ public enum Pointer: PointerType {
 			return oid
 		}
 	}
-	
+
 	public var type: git_otype {
 		switch self {
 		case .Commit:
@@ -53,7 +53,7 @@ public enum Pointer: PointerType {
 			return GIT_OBJ_TAG
 		}
 	}
-	
+
 	/// Create an instance with an OID and a libgit2 `git_otype`.
 	init?(oid: OID, type: git_otype) {
 		switch type {
@@ -94,7 +94,7 @@ extension Pointer: CustomStringConvertible {
 
 public struct PointerTo<T: ObjectType>: PointerType {
 	public let oid: OID
-	
+
 	public var type: git_otype {
 		return T.type
 	}

--- a/SwiftGit2/References.swift
+++ b/SwiftGit2/References.swift
@@ -12,10 +12,10 @@ import libgit2
 public protocol ReferenceType {
 	/// The full name of the reference (e.g., `refs/heads/master`).
 	var longName: String { get }
-	
+
 	/// The short human-readable name of the reference if one exists (e.g., `master`).
 	var shortName: String? { get }
-	
+
 	/// The OID of the referenced object.
 	var oid: OID { get }
 }
@@ -40,13 +40,13 @@ internal func referenceWithLibGit2Reference(_ pointer: OpaquePointer) -> Referen
 public struct Reference: ReferenceType {
 	/// The full name of the reference (e.g., `refs/heads/master`).
 	public let longName: String
-	
+
 	/// The short human-readable name of the reference if one exists (e.g., `master`).
 	public let shortName: String?
-	
+
 	/// The OID of the referenced object.
 	public let oid: OID
-	
+
 	/// Create an instance with a libgit2 `git_reference` object.
 	public init(_ pointer: OpaquePointer) {
 		let shorthand = String(validatingUTF8: git_reference_shorthand(pointer))!
@@ -66,32 +66,32 @@ extension Reference: Hashable {
 public struct Branch: ReferenceType {
 	/// The full name of the reference (e.g., `refs/heads/master`).
 	public let longName: String
-	
+
 	/// The short human-readable name of the branch (e.g., `master`).
 	public let name: String
-	
+
 	/// A pointer to the referenced commit.
 	public let commit: PointerTo<Commit>
-	
+
 	// MARK: Derived Properties
-	
+
 	/// The short human-readable name of the branch (e.g., `master`).
 	///
 	/// This is the same as `name`, but is declared with an Optional type to adhere to
 	/// `ReferenceType`.
 	public var shortName: String? { return name }
-	
+
 	/// The OID of the referenced object.
 	///
 	/// This is the same as `commit.oid`, but is declared here to adhere to `ReferenceType`.
 	public var oid: OID { return commit.oid }
-	
+
 	/// Whether the branch is a local branch.
 	public var isLocal: Bool { return longName.hasPrefix("refs/heads/") }
-	
+
 	/// Whether the branch is a remote branch.
 	public var isRemote: Bool { return longName.hasPrefix("refs/remotes/") }
-	
+
 	/// Create an instance with a libgit2 `git_reference` object.
 	///
 	/// Returns `nil` if the pointer isn't a branch.
@@ -102,9 +102,9 @@ public struct Branch: ReferenceType {
 			return nil
 		}
 		name = String(validatingUTF8: namePointer!)!
-		
+
 		longName = String(validatingUTF8: git_reference_name(pointer))!
-		
+
 		var oid: OID
 		if git_reference_type(pointer).rawValue == GIT_REF_SYMBOLIC.rawValue {
 			var resolved: OpaquePointer? = nil
@@ -131,10 +131,10 @@ extension Branch: Hashable {
 public enum TagReference: ReferenceType {
 	/// A lightweight tag, which is just a name and an OID.
 	case Lightweight(String, OID)
-	
+
 	/// An annotated tag, which points to a Tag object.
 	case Annotated(String, Tag)
-	
+
 	/// The full name of the reference (e.g., `refs/tags/my-tag`).
 	public var longName: String {
 		switch self {
@@ -144,12 +144,12 @@ public enum TagReference: ReferenceType {
 			return name
 		}
 	}
-	
+
 	/// The short human-readable name of the branch (e.g., `master`).
 	public var name: String {
 		return longName.substring(from: "refs/tags/".endIndex)
 	}
-	
+
 	/// The OID of the target object.
 	///
 	/// If this is an annotated tag, the OID will be the tag's target.
@@ -161,15 +161,15 @@ public enum TagReference: ReferenceType {
 			return tag.target.oid
 		}
 	}
-	
+
 	// MARK: Derived Properties
-	
+
 	/// The short human-readable name of the branch (e.g., `master`).
 	///
 	/// This is the same as `name`, but is declared with an Optional type to adhere to
 	/// `ReferenceType`.
 	public var shortName: String? { return name }
-	
+
 	/// Create an instance with a libgit2 `git_reference` object.
 	///
 	/// Returns `nil` if the pointer isn't a branch.
@@ -177,11 +177,11 @@ public enum TagReference: ReferenceType {
 		if git_reference_is_tag(pointer) == 0 {
 			return nil
 		}
-		
+
 		let name = String(validatingUTF8: git_reference_name(pointer))!
 		let repo = git_reference_owner(pointer)
 		var oid = git_reference_target(pointer).pointee
-		
+
 		var pointer: OpaquePointer? = nil
 		let result = git_object_lookup(&pointer, repo, &oid, GIT_OBJ_TAG)
 		if result == GIT_OK.rawValue {

--- a/SwiftGit2/Remotes.swift
+++ b/SwiftGit2/Remotes.swift
@@ -12,12 +12,12 @@ import libgit2
 public struct Remote {
 	/// The name of the remote.
 	public let name: String
-	
+
 	/// The URL of the remote.
 	///
 	/// This may be an SSH URL, which isn't representable using `NSURL`.
 	public let URL: String
-	
+
 	/// Create an instance with a libgit2 `git_remote`.
 	public init(_ pointer: OpaquePointer) {
 		name = String(validatingUTF8: git_remote_name(pointer))!

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -11,26 +11,26 @@ import SwiftGit2
 import ZipArchive
 
 final class Fixtures {
-	
+
 	// MARK: Lifecycle
-	
+
 	class var sharedInstance: Fixtures {
 		struct Singleton {
 			static let instance = Fixtures()
 		}
 		return Singleton.instance
 	}
-	
+
 	init() {
 		directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 			.appendingPathComponent("org.libgit2.SwiftGit2")
 			.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
 	}
-	
+
 	// MARK: - Setup and Teardown
-	
+
 	let directoryURL: URL
-	
+
 	func setUp() {
 		try! FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
 
@@ -42,33 +42,33 @@ final class Fixtures {
 		let bundleIdentifier = String(format: "org.libgit2.SwiftGit2-%@Tests", arguments: [platform])
 		let bundle = Bundle(identifier: bundleIdentifier)!
 		let zipURLs = bundle.urls(forResourcesWithExtension: "zip", subdirectory: nil)!
-		
+
 		for URL in zipURLs {
 			SSZipArchive.unzipFile(atPath: URL.path, toDestination: directoryURL.path)
 		}
 	}
-	
+
 	func tearDown() {
 		try! FileManager.default.removeItem(at: directoryURL)
 	}
-	
+
 	// MARK: - Helpers
-	
+
 	func repository(named name: String) -> Repository {
 		let url = directoryURL.appendingPathComponent(name, isDirectory: true)
 		return Repository.at(url).value!
 	}
-	
+
 	// MARK: - The Fixtures
-	
+
 	class var detachedHeadRepository: Repository {
 		return Fixtures.sharedInstance.repository(named: "detached-head")
 	}
-	
+
 	class var simpleRepository: Repository {
 		return Fixtures.sharedInstance.repository(named: "simple-repository")
 	}
-	
+
 	class var mantleRepository: Repository {
 		return Fixtures.sharedInstance.repository(named: "Mantle")
 	}

--- a/SwiftGit2Tests/FixturesSpec.swift
+++ b/SwiftGit2Tests/FixturesSpec.swift
@@ -13,7 +13,7 @@ class FixturesSpec: QuickSpec {
 		beforeSuite {
 			Fixtures.sharedInstance.setUp()
 		}
-		
+
 		afterSuite {
 			Fixtures.sharedInstance.tearDown()
 		}

--- a/SwiftGit2Tests/OIDSpec.swift
+++ b/SwiftGit2Tests/OIDSpec.swift
@@ -25,19 +25,19 @@ class OIDSpec: QuickSpec {
 			it("should not be nil if string is just right") {
 				expect(OID(string: "1234567890123456789012345678ABCDEFabcdef")).notTo(beNil())
 			}
-			
+
 			it("should be nil with non-hex characters") {
 				expect(OID(string: "123456789012345678901234567890123456789j")).to(beNil())
 			}
 		}
-		
+
 		describe("OID(oid)") {
 			it("should equal an OID with the same git_oid") {
 				let oid = OID(string: "1234567890123456789012345678901234567890")!
 				expect(OID(oid.oid)).to(equal(oid))
 			}
 		}
-		
+
 		describe("OID.description") {
 			it("should return the SHA") {
 				let SHA = "1234567890123456789012345678901234567890"
@@ -45,7 +45,7 @@ class OIDSpec: QuickSpec {
 				expect(oid.description).to(equal(SHA))
 			}
 		}
-		
+
 		describe("==(OID, OID)") {
 			it("should be equal when identical") {
 				let SHA = "1234567890123456789012345678901234567890"
@@ -53,14 +53,14 @@ class OIDSpec: QuickSpec {
 				let oid2 = OID(string: SHA)!
 				expect(oid1).to(equal(oid2))
 			}
-			
+
 			it("should be not equal when different") {
 				let oid1 = OID(string: "1234567890123456789012345678901234567890")!
 				let oid2 = OID(string: "0000000000000000000000000000000000000000")!
 				expect(oid1).notTo(equal(oid2))
 			}
 		}
-		
+
 		describe("OID.hashValue") {
 			it("should be equal when OIDs are equal") {
 				let SHA = "1234567890123456789012345678901234567890"

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -32,56 +32,56 @@ class SignatureSpec: QuickSpec {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let raw_signature = repo.withGitObject(oid) { git_commit_author($0).pointee }
 				let signature = Signature(raw_signature)
-				
+
 				expect(signature.name).to(equal("Matt Diephouse"))
 				expect(signature.email).to(equal("matt@diephouse.com"))
 				expect(signature.time).to(equal(Date(timeIntervalSince1970: 1416186947)))
 				expect(signature.timeZone.abbreviation()).to(equal("GMT-5"))
 			}
 		}
-		
+
 		describe("==(Signature, Signature)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let author1 = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
-				
+
 				expect(author1).to(equal(author2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
-				
+
 				let author1 = repo.withGitObject(oid1) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = repo.withGitObject(oid2) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
-				
+
 				expect(author1).notTo(equal(author2))
 			}
 		}
-		
+
 		describe("Signature.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let author1 = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
 				}
 				let author2 = author1
-				
+
 				expect(author1.hashValue).to(equal(author2.hashValue))
 			}
 		}
@@ -94,7 +94,7 @@ class CommitSpec: QuickSpec {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!
-				
+
 				let commit = repo.withGitObject(oid) { Commit($0) }
 				let author = repo.withGitObject(oid) { commit in
 					Signature(git_commit_author(commit).pointee)
@@ -113,19 +113,19 @@ class CommitSpec: QuickSpec {
 				expect(commit.author).to(equal(author))
 				expect(commit.committer).to(equal(committer))
 			}
-			
+
 			it("should handle 0 parents") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let commit = repo.withGitObject(oid) { Commit($0) }
 				expect(commit.parents).to(equal([]))
 			}
-			
+
 			it("should handle multiple parents") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
-				
+
 				let commit = repo.withGitObject(oid) { Commit($0) }
 				let parents: [PointerTo<Commit>] = [
 					PointerTo(OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!),
@@ -134,33 +134,33 @@ class CommitSpec: QuickSpec {
 				expect(commit.parents).to(equal(parents))
 			}
 		}
-		
+
 		describe("==(Commit, Commit)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let commit1 = repo.withGitObject(oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1).to(equal(commit2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
 				let oid2 = OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!
-				
+
 				let commit1 = repo.withGitObject(oid1) { Commit($0) }
 				let commit2 = repo.withGitObject(oid2) { Commit($0) }
 				expect(commit1).notTo(equal(commit2))
 			}
 		}
-		
+
 		describe("Commit.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let commit1 = repo.withGitObject(oid) { Commit($0) }
 				let commit2 = commit1
 				expect(commit1.hashValue).to(equal(commit2.hashValue))
@@ -176,52 +176,52 @@ class TreeEntrySpec: QuickSpec {
 				let attributes = Int32(GIT_FILEMODE_BLOB.rawValue)
 				let object = Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)
 				let name = "README.md"
-				
+
 				let entry = Tree.Entry(attributes: attributes, object: object, name: name)
 				expect(entry.attributes).to(equal(attributes))
 				expect(entry.object).to(equal(object))
 				expect(entry.name).to(equal(name))
 			}
 		}
-		
+
 		describe("Tree.Entry(pointer)") {
 			it("should set its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let entry = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry.attributes).to(equal(Int32(GIT_FILEMODE_BLOB.rawValue)))
 				expect(entry.object).to(equal(Pointer.Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!)))
 				expect(entry.name).to(equal("README.md"))
 			}
 		}
-		
+
 		describe("==(Tree.Entry, Tree.Entry)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let entry1 = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1).to(equal(entry2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let entry1 = repo.withGitObject(oid1) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = repo.withGitObject(oid2) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				expect(entry1).notTo(equal(entry2))
 			}
 		}
-		
+
 		describe("Tree.Entry.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let entry1 = repo.withGitObject(oid) { Tree.Entry(git_tree_entry_byindex($0, 0)) }
 				let entry2 = entry1
 				expect(entry1.hashValue).to(equal(entry2.hashValue))
@@ -236,7 +236,7 @@ class TreeSpec: QuickSpec {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let tree = repo.withGitObject(oid) { Tree($0) }
 				let entries = [
 					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
@@ -244,33 +244,33 @@ class TreeSpec: QuickSpec {
 				expect(tree.entries).to(equal(entries))
 			}
 		}
-		
+
 		describe("==(Tree, Tree)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let tree1 = repo.withGitObject(oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1).to(equal(tree2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
 				let oid2 = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let tree1 = repo.withGitObject(oid1) { Tree($0) }
 				let tree2 = repo.withGitObject(oid2) { Tree($0) }
 				expect(tree1).notTo(equal(tree2))
 			}
 		}
-		
+
 		describe("Tree.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "219e9f39c2fb59ed1dfb3e78ed75055a57528f31")!
-				
+
 				let tree1 = repo.withGitObject(oid) { Tree($0) }
 				let tree2 = tree1
 				expect(tree1.hashValue).to(equal(tree2.hashValue))
@@ -285,7 +285,7 @@ class BlobSpec: QuickSpec {
 			it("should initialize its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let blob = repo.withGitObject(oid) { Blob($0) }
 				let contents = "# Simple Repository\nA simple repository used for testing SwiftGit2.\n\n## Branches\n\n- master\n\n"
 				let data = contents.data(using: String.Encoding.utf8)!
@@ -293,33 +293,33 @@ class BlobSpec: QuickSpec {
 				expect(blob.data).to(equal(data))
 			}
 		}
-		
+
 		describe("==(Blob, Blob)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let blob1 = repo.withGitObject(oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1).to(equal(blob2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
 				let oid2 = OID(string: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")!
-				
+
 				let blob1 = repo.withGitObject(oid1) { Blob($0) }
 				let blob2 = repo.withGitObject(oid2) { Blob($0) }
 				expect(blob1).notTo(equal(blob2))
 			}
 		}
-		
+
 		describe("Blob.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let blob1 = repo.withGitObject(oid) { Blob($0) }
 				let blob2 = blob1
 				expect(blob1.hashValue).to(equal(blob2.hashValue))
@@ -334,10 +334,10 @@ class TagSpec: QuickSpec {
 			it("should set its properties") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let tag = repo.withGitObject(oid) { Tag($0) }
 				let tagger = repo.withGitObject(oid) { Signature(git_tag_tagger($0).pointee) }
-				
+
 				expect(tag.oid).to(equal(oid))
 				expect(tag.target).to(equal(Pointer.Commit(OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!)))
 				expect(tag.name).to(equal("tag-1"))
@@ -345,33 +345,33 @@ class TagSpec: QuickSpec {
 				expect(tag.message).to(equal("tag-1\n"))
 			}
 		}
-		
+
 		describe("==(Tag, Tag)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let tag1 = repo.withGitObject(oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1).to(equal(tag2))
 			}
-			
+
 			it("should be false with unequal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid1 = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
 				let oid2 = OID(string: "13bda91157f255ab224ff88d0a11a82041c9d0c1")!
-				
+
 				let tag1 = repo.withGitObject(oid1) { Tag($0) }
 				let tag2 = repo.withGitObject(oid2) { Tag($0) }
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
-		
+
 		describe("Tag.hashValue") {
 			it("should be equal with equal objects") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let tag1 = repo.withGitObject(oid) { Tag($0) }
 				let tag2 = tag1
 				expect(tag1.hashValue).to(equal(tag2.hashValue))

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -36,7 +36,7 @@ class ReferenceSpec: QuickSpec {
 				expect(ref.oid).to(equal(OID(string: "c4ed03a6b7d7ce837d31d83757febbe84dd465fd")!))
 			}
 		}
-		
+
 		describe("==(Reference, Reference)") {
 			it("should be true with equal references") {
 				let repo = Fixtures.simpleRepository
@@ -44,7 +44,7 @@ class ReferenceSpec: QuickSpec {
 				let ref2 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
 				expect(ref1).to(equal(ref2))
 			}
-			
+
 			it("should be false with unequal references") {
 				let repo = Fixtures.simpleRepository
 				let ref1 = repo.withGitReference(named: "refs/heads/master") { Reference($0) }
@@ -78,7 +78,7 @@ class BranchSpec: QuickSpec {
 				expect(branch.isLocal).to(beTrue())
 				expect(branch.isRemote).to(beFalse())
 			}
-			
+
 			it("should work with symoblic refs") {
 				let repo = Fixtures.mantleRepository
 				let branch = repo.withGitReference(named: "refs/remotes/origin/HEAD") { Branch($0)! }
@@ -91,7 +91,7 @@ class BranchSpec: QuickSpec {
 				expect(branch.isRemote).to(beTrue())
 			}
 		}
-		
+
 		describe("==(Branch, Branch)") {
 			it("should be true with equal branches") {
 				let repo = Fixtures.simpleRepository
@@ -99,7 +99,7 @@ class BranchSpec: QuickSpec {
 				let branch2 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
 				expect(branch1).to(equal(branch2))
 			}
-			
+
 			it("should be false with unequal branches") {
 				let repo = Fixtures.simpleRepository
 				let branch1 = repo.withGitReference(named: "refs/heads/master") { Branch($0)! }
@@ -130,7 +130,7 @@ class TagReferenceSpec: QuickSpec {
 				expect(tag.shortName).to(equal(tag.name))
 				expect(tag.oid).to(equal(OID(string: "24e1e40ee77525d9e279f079f9906ad6d98c8940")!))
 			}
-			
+
 			it("should work with a lightweight tag") {
 				let repo = Fixtures.mantleRepository
 				let tag = repo.withGitReference(named: "refs/tags/1.5.4") { TagReference($0)! }
@@ -139,14 +139,14 @@ class TagReferenceSpec: QuickSpec {
 				expect(tag.shortName).to(equal(tag.name))
 				expect(tag.oid).to(equal(OID(string: "d9dc95002cfbf3929d2b70d2c8a77e6bf5b1b88a")!))
 			}
-			
+
 			it("should return nil if not a tag") {
 				let repo = Fixtures.simpleRepository
 				let tag = repo.withGitReference(named: "refs/heads/master") { TagReference($0) }
 				expect(tag).to(beNil())
 			}
 		}
-		
+
 		describe("==(TagReference, TagReference)") {
 			it("should be true with equal tag references") {
 				let repo = Fixtures.simpleRepository
@@ -154,7 +154,7 @@ class TagReferenceSpec: QuickSpec {
 				let tag2 = repo.withGitReference(named: "refs/tags/tag-2") { TagReference($0)! }
 				expect(tag1).to(equal(tag2))
 			}
-			
+
 			it("should be false with unequal tag references") {
 				let repo = Fixtures.simpleRepository
 				let tag1 = repo.withGitReference(named: "refs/tags/tag-1") { TagReference($0)! }
@@ -162,7 +162,7 @@ class TagReferenceSpec: QuickSpec {
 				expect(tag1).notTo(equal(tag2))
 			}
 		}
-		
+
 		describe("TagReference.hashValue") {
 			it("should be equal with equal references") {
 				let repo = Fixtures.simpleRepository

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -31,12 +31,12 @@ class RemoteSpec: QuickSpec {
 			it("should initialize its properties") {
 				let repo = Fixtures.mantleRepository
 				let remote = repo.withGitRemote(named: "upstream") { Remote($0) }
-				
+
 				expect(remote.name).to(equal("upstream"))
 				expect(remote.URL).to(equal("git@github.com:Mantle/Mantle.git"))
 			}
 		}
-		
+
 		describe("==(Remote, Remote)") {
 			it("should be true with equal objects") {
 				let repo = Fixtures.mantleRepository
@@ -44,7 +44,7 @@ class RemoteSpec: QuickSpec {
 				let remote2 = remote1
 				expect(remote1).to(equal(remote2))
 			}
-			
+
 			it("should be false with unequal objcets") {
 				let repo = Fixtures.mantleRepository
 				let origin = repo.withGitRemote(named: "origin") { Remote($0) }
@@ -52,7 +52,7 @@ class RemoteSpec: QuickSpec {
 				expect(origin).notTo(equal(upstream))
 			}
 		}
-		
+
 		describe("Remote.hashValue") {
 			it("should be equal with equal objcets") {
 				let repo = Fixtures.mantleRepository

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -19,7 +19,7 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				expect(repo.directoryURL).notTo(beNil())
 			}
-			
+
 			it("should fail if the repo doesn't exist") {
 				let url = URL(fileURLWithPath: "blah")
 				let result = Repository.at(url)
@@ -114,115 +114,115 @@ class RepositorySpec: QuickSpec {
 				}
 			}
 		}
-		
+
 		describe("Repository.blob(_:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let result = repo.blob(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
-			
+
 			it("should error if the blob doesn't exist") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				
+
 				let result = repo.blob(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
-			
+
 			it("should error if the oid doesn't point to a blob") {
 				let repo = Fixtures.simpleRepository
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let result = repo.blob(oid)
 				expect(result).to(haveFailed())
 			}
 		}
-		
+
 		describe("Repository.commit(_:)") {
 			it("should return the commit if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let result = repo.commit(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
-			
+
 			it("should error if the commit doesn't exist") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				
+
 				let result = repo.commit(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
-			
+
 			it("should error if the oid doesn't point to a commit") {
 				let repo = Fixtures.simpleRepository
 				// This is a tree in the repository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let result = repo.commit(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.tag(_:)") {
 			it("should return the tag if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let result = repo.tag(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
-			
+
 			it("should error if the tag doesn't exist") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				
+
 				let result = repo.tag(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
-			
+
 			it("should error if the oid doesn't point to a tag") {
 				let repo = Fixtures.simpleRepository
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let result = repo.tag(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.tree(_:)") {
 			it("should return the tree if it exists") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let result = repo.tree(oid)
 				expect(result.map { $0.oid }).to(haveSucceeded(equal(oid)))
 			}
-			
+
 			it("should error if the tree doesn't exist") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
-				
+
 				let result = repo.tree(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
-			
+
 			it("should error if the oid doesn't point to a tree") {
 				let repo = Fixtures.simpleRepository
 				// This is a commit in the repository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let result = repo.tree(oid)
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.object(_:)") {
 			it("should work with a blob") {
 				let repo   = Fixtures.simpleRepository
@@ -231,7 +231,7 @@ class RepositorySpec: QuickSpec {
 				let result = repo.object(oid)
 				expect(result.map { $0 as! Blob }).to(haveSucceeded(equal(blob)))
 			}
-			
+
 			it("should work with a commit") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
@@ -239,7 +239,7 @@ class RepositorySpec: QuickSpec {
 				let result = repo.object(oid)
 				expect(result.map { $0 as! Commit }).to(haveSucceeded(equal(commit)))
 			}
-			
+
 			it("should work with a tag") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
@@ -247,7 +247,7 @@ class RepositorySpec: QuickSpec {
 				let result = repo.object(oid)
 				expect(result.map { $0 as! Tag }).to(haveSucceeded(equal(tag)))
 			}
-			
+
 			it("should work with a tree") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
@@ -255,7 +255,7 @@ class RepositorySpec: QuickSpec {
 				let result = repo.object(oid)
 				expect(result.map { $0 as! Tree }).to(haveSucceeded(equal(tree)))
 			}
-			
+
 			it("should error if there's no object with that oid") {
 				let repo   = Fixtures.simpleRepository
 				let oid    = OID(string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
@@ -263,94 +263,94 @@ class RepositorySpec: QuickSpec {
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.object(from: PointerTo)") {
 			it("should work with commits") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let pointer = PointerTo<Commit>(oid)
 				let commit = repo.commit(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(commit)))
 			}
-			
+
 			it("should work with trees") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let pointer = PointerTo<Tree>(oid)
 				let tree = repo.tree(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tree)))
 			}
-			
+
 			it("should work with blobs") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let pointer = PointerTo<Blob>(oid)
 				let blob = repo.blob(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(blob)))
 			}
-			
+
 			it("should work with tags") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let pointer = PointerTo<Tag>(oid)
 				let tag = repo.tag(oid).value!
 				expect(repo.object(from: pointer)).to(haveSucceeded(equal(tag)))
 			}
 		}
-		
+
 		describe("Repository.object(from: Pointer)") {
 			it("should work with commits") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "dc220a3f0c22920dab86d4a8d3a3cb7e69d6205a")!
-				
+
 				let pointer = Pointer.Commit(oid)
 				let commit = repo.commit(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Commit }
 				expect(result).to(haveSucceeded(equal(commit)))
 			}
-			
+
 			it("should work with trees") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "f93e3a1a1525fb5b91020da86e44810c87a2d7bc")!
-				
+
 				let pointer = Pointer.Tree(oid)
 				let tree = repo.tree(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tree }
 				expect(result).to(haveSucceeded(equal(tree)))
 			}
-			
+
 			it("should work with blobs") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!
-				
+
 				let pointer = Pointer.Blob(oid)
 				let blob = repo.blob(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Blob }
 				expect(result).to(haveSucceeded(equal(blob)))
 			}
-			
+
 			it("should work with tags") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "57943b8ee00348180ceeedc960451562750f6d33")!
-				
+
 				let pointer = Pointer.Tag(oid)
 				let tag = repo.tag(oid).value!
 				let result = repo.object(from: pointer).map { $0 as! Tag }
 				expect(result).to(haveSucceeded(equal(tag)))
 			}
 		}
-		
+
 		describe("Repository.allRemotes()") {
 			it("should return an empty list if there are no remotes") {
 				let repo = Fixtures.simpleRepository
 				let result = repo.allRemotes()
 				expect(result).to(haveSucceeded(beEmpty()))
 			}
-			
+
 			it("should return all the remotes") {
 				let repo = Fixtures.mantleRepository
 				let remotes = repo.allRemotes()
@@ -359,21 +359,21 @@ class RepositorySpec: QuickSpec {
 				expect(names).to(haveSucceeded(contain("origin", "upstream")))
 			}
 		}
-		
+
 		describe("Repository.remote(named:)") {
 			it("should return the remote if it exists") {
 				let repo = Fixtures.mantleRepository
 				let result = repo.remote(named: "upstream")
 				expect(result.map { $0.name }).to(haveSucceeded(equal("upstream")))
 			}
-			
+
 			it("should error if the remote doesn't exist") {
 				let repo = Fixtures.simpleRepository
 				let result = repo.remote(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.reference(named:)") {
 			it("should return a local branch if it exists") {
 				let name = "refs/heads/master"
@@ -388,26 +388,26 @@ class RepositorySpec: QuickSpec {
 				expect(result.map { $0.longName }).to(haveSucceeded(equal(name)))
 				expect(result.value as? Branch).notTo(beNil())
 			}
-			
+
 			it("should return a tag if it exists") {
 				let name = "refs/tags/tag-2"
 				let result = Fixtures.simpleRepository.reference(named: name)
 				expect(result.value?.longName).to(equal(name))
 				expect(result.value as? TagReference).notTo(beNil())
 			}
-			
+
 			it("should return the reference if it exists") {
 				let name = "refs/other-ref"
 				let result = Fixtures.simpleRepository.reference(named: name)
 				expect(result.value?.longName).to(equal(name))
 			}
-			
+
 			it("should error if the reference doesn't exist") {
 				let result = Fixtures.simpleRepository.reference(named: "refs/heads/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.localBranches()") {
 			it("should return all the local branches") {
 				let repo = Fixtures.simpleRepository
@@ -419,7 +419,7 @@ class RepositorySpec: QuickSpec {
 				expect(repo.localBranches().value).to(equal(expected))
 			}
 		}
-		
+
 		describe("Repository.remoteBranches()") {
 			it("should return all the remote branches") {
 				let repo = Fixtures.mantleRepository
@@ -450,31 +450,31 @@ class RepositorySpec: QuickSpec {
 				expect(actual.map { $0.name }).to(equal(expectedNames))
 			}
 		}
-		
+
 		describe("Repository.localBranch(named:)") {
 			it("should return the branch if it exists") {
 				let result = Fixtures.simpleRepository.localBranch(named: "master")
 				expect(result.value?.longName).to(equal("refs/heads/master"))
 			}
-			
+
 			it("should error if the branch doesn't exists") {
 				let result = Fixtures.simpleRepository.localBranch(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.remoteBranch(named:)") {
 			it("should return the branch if it exists") {
 				let result = Fixtures.mantleRepository.remoteBranch(named: "upstream/master")
 				expect(result.value?.longName).to(equal("refs/remotes/upstream/master"))
 			}
-			
+
 			it("should error if the branch doesn't exists") {
 				let result = Fixtures.simpleRepository.remoteBranch(named: "origin/nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.allTags()") {
 			it("should return all the tags") {
 				let repo = Fixtures.simpleRepository
@@ -485,19 +485,19 @@ class RepositorySpec: QuickSpec {
 				expect(repo.allTags().value).to(equal(expected))
 			}
 		}
-		
+
 		describe("Repository.tag(named:)") {
 			it("should return the tag if it exists") {
 				let result = Fixtures.simpleRepository.tag(named: "tag-2")
 				expect(result.value?.longName).to(equal("refs/tags/tag-2"))
 			}
-			
+
 			it("should error if the branch doesn't exists") {
 				let result = Fixtures.simpleRepository.tag(named: "nonexistent")
 				expect(result).to(haveFailed(beAnError(domain: equal(libGit2ErrorDomain))))
 			}
 		}
-		
+
 		describe("Repository.HEAD()") {
 			it("should work when on a branch") {
 				let result = Fixtures.simpleRepository.HEAD()
@@ -505,7 +505,7 @@ class RepositorySpec: QuickSpec {
 				expect(result.value?.shortName).to(equal("master"))
 				expect(result.value as? Branch).notTo(beNil())
 			}
-			
+
 			it("should work when on a detached HEAD") {
 				let result = Fixtures.detachedHeadRepository.HEAD()
 				expect(result.value?.longName).to(equal("HEAD"))
@@ -514,48 +514,48 @@ class RepositorySpec: QuickSpec {
 				expect(result.value as? Reference).notTo(beNil())
 			}
 		}
-		
+
 		describe("Repository.setHEAD(OID)") {
 			it("should set HEAD to the OID") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
-				
+
 				expect(repo.setHEAD(oid)).to(haveSucceeded())
 				let HEAD = repo.HEAD().value
 				expect(HEAD?.longName).to(equal("HEAD"))
 				expect(HEAD?.oid).to(equal(oid))
-				
+
 				expect(repo.setHEAD(repo.localBranch(named: "master").value!)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 			}
 		}
-		
+
 		describe("Repository.setHEAD(ReferenceType)") {
 			it("should set HEAD to a branch") {
 				let repo = Fixtures.detachedHeadRepository
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
-				
+
 				let branch = repo.localBranch(named: "another-branch").value!
 				expect(repo.setHEAD(branch)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
-				
+
 				expect(repo.setHEAD(oid)).to(haveSucceeded())
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 			}
 		}
-		
+
 		describe("Repository.checkout()") {
 			// We're not really equipped to test this yet. :(
 		}
-		
+
 		describe("Repository.checkout(OID)") {
 			it("should set HEAD") {
 				let repo = Fixtures.simpleRepository
 				let oid = OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
-				
+
 				expect(repo.checkout(oid, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				let HEAD = repo.HEAD().value
 				expect(HEAD?.longName).to(equal("HEAD"))
@@ -579,17 +579,17 @@ class RepositorySpec: QuickSpec {
 				expect(HEAD?.oid).to(equal(oid))
 			}
 		}
-		
+
 		describe("Repository.checkout(ReferenceType)") {
 			it("should set HEAD") {
 				let repo = Fixtures.detachedHeadRepository
 				let oid = repo.HEAD().value!.oid
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
-				
+
 				let branch = repo.localBranch(named: "another-branch").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.shortName).to(equal(branch.name))
-				
+
 				expect(repo.checkout(oid, strategy: CheckoutStrategy.None)).to(haveSucceeded())
 				expect(repo.HEAD().value?.longName).to(equal("HEAD"))
 			}


### PR DESCRIPTION
Enable SwiftLint `trailing_whitespace` linting for blank lines.

Closes #73.