### PR TITLE
Update lint configuration for Swiftlint 0.15

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,7 +3,6 @@ disabled_rules:
   - force_cast
   - force_try
   - function_body_length
-  - line_length
   - type_body_length
 
 opt_in_rules:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,12 +7,16 @@ disabled_rules:
   - type_body_length
 
 opt_in_rules:
+  - attributes
+  - closure_end_indentation
   - closure_spacing
   - conditional_returns_on_newline
   - empty_count
   - explicit_init
+  - first_where
   - overridden_super_call
   - private_outlet
+  - prohibited_super_call
   - redundant_nil_coalescing
   - switch_case_on_newline
 

--- a/SwiftGit2/Credentials.swift
+++ b/SwiftGit2/Credentials.swift
@@ -31,9 +31,10 @@ public enum Credentials {
 }
 
 /// Handle the request of credentials, passing through to a wrapped block after converting the arguments.
-/// Converts the result to the correct error code required by libgit2 (0 = success, 1 = rejected setting creds, -1 error)
-internal func credentialsCallback(cred: UnsafeMutablePointer<UnsafeMutablePointer<git_cred>?>?, _: UnsafePointer<Int8>?, _: UnsafePointer<Int8>?, _: UInt32,
-	payload: UnsafeMutableRawPointer?) -> Int32 {
+/// Converts the result to the correct error code required by libgit2 (0 = success, 1 = rejected setting creds,
+/// -1 = error)
+internal func credentialsCallback(cred: UnsafeMutablePointer<UnsafeMutablePointer<git_cred>?>?, _: UnsafePointer<Int8>?,
+                                  _: UnsafePointer<Int8>?, _: UInt32, payload: UnsafeMutableRawPointer?) -> Int32 {
 	let result: Int32
 
 	switch Credentials.fromPointer(payload!) {

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -14,7 +14,8 @@ public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void
 
 /// Helper function used as the libgit2 progress callback in git_checkout_options.
 /// This is a function with a type signature of git_checkout_progress_cb.
-private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps: Int, totalSteps: Int, payload: UnsafeMutableRawPointer?) -> Void {
+private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps: Int, totalSteps: Int,
+                                      payload: UnsafeMutableRawPointer?) -> Void {
 	if let payload = payload {
 		let buffer = payload.assumingMemoryBound(to: CheckoutProgressBlock.self)
 		let block: CheckoutProgressBlock
@@ -33,7 +34,8 @@ private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps
 /// :param: strategy The strategy to be used when checking out the repo, see CheckoutStrategy
 /// :param: progress A block that's called with the progress of the checkout.
 /// :returns: Returns a git_checkout_options struct with the progress members set.
-private func checkoutOptions(strategy: CheckoutStrategy, progress: CheckoutProgressBlock? = nil) -> git_checkout_options {
+private func checkoutOptions(strategy: CheckoutStrategy,
+                             progress: CheckoutProgressBlock? = nil) -> git_checkout_options {
 	// Do this because GIT_CHECKOUT_OPTIONS_INIT is unavailable in swift
 	let pointer = UnsafeMutablePointer<git_checkout_options>.allocate(capacity: 1)
 	git_checkout_init_options(pointer, UInt32(GIT_CHECKOUT_OPTIONS_VERSION))
@@ -67,8 +69,7 @@ private func fetchOptions(credentials: Credentials) -> git_fetch_options {
 }
 
 private func cloneOptions(bare: Bool = false, localClone: Bool = false, fetchOptions: git_fetch_options? = nil,
-	checkoutOptions: git_checkout_options? = nil) -> git_clone_options {
-
+                          checkoutOptions: git_checkout_options? = nil) -> git_clone_options {
 	let pointer = UnsafeMutablePointer<git_clone_options>.allocate(capacity: 1)
 	git_clone_init_options(pointer, UInt32(GIT_CLONE_OPTIONS_VERSION))
 
@@ -129,7 +130,8 @@ final public class Repository {
 	///
 	/// Returns a `Result` with a `Repository` or an error.
 	class public func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
-		credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe, checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
+	                        credentials: Credentials = .Default(), checkoutStrategy: CheckoutStrategy = .Safe,
+	                        checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
 			var options = cloneOptions(
 				bare: bare, localClone: localClone,
 				fetchOptions: fetchOptions(credentials: credentials),
@@ -185,7 +187,8 @@ final public class Repository {
 	///
 	/// Returns the result of calling `transform` or an error if the object
 	/// cannot be loaded.
-	private func withGitObject<T>(_ oid: OID, type: git_otype, transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
+	private func withGitObject<T>(_ oid: OID, type: git_otype,
+	                              transform: (OpaquePointer) -> Result<T, NSError>) -> Result<T, NSError> {
 		var pointer: OpaquePointer? = nil
 		var oid = oid.oid
 		let result = git_object_lookup(&pointer, self.pointer, &oid, type)
@@ -491,7 +494,8 @@ final public class Repository {
 	/// :param: strategy The checkout strategy to use.
 	/// :param: progress A block that's called with the progress of the checkout.
 	/// :returns: Returns a result with void or the error that occurred.
-	public func checkout(_ oid: OID, strategy: CheckoutStrategy, progress: CheckoutProgressBlock? = nil) -> Result<(), NSError> {
+	public func checkout(_ oid: OID, strategy: CheckoutStrategy,
+	                     progress: CheckoutProgressBlock? = nil) -> Result<(), NSError> {
 		return setHEAD(oid).flatMap { self.checkout(strategy: strategy, progress: progress) }
 	}
 
@@ -501,7 +505,8 @@ final public class Repository {
 	/// :param: strategy The checkout strategy to use.
 	/// :param: progress A block that's called with the progress of the checkout.
 	/// :returns: Returns a result with void or the error that occurred.
-	public func checkout(_ reference: ReferenceType, strategy: CheckoutStrategy, progress: CheckoutProgressBlock? = nil) -> Result<(), NSError> {
+	public func checkout(_ reference: ReferenceType, strategy: CheckoutStrategy,
+	                     progress: CheckoutProgressBlock? = nil) -> Result<(), NSError> {
 		return setHEAD(reference).flatMap { self.checkout(strategy: strategy, progress: progress) }
 	}
 }

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -239,7 +239,9 @@ class TreeSpec: QuickSpec {
 
 				let tree = repo.withGitObject(oid) { Tree($0) }
 				let entries = [
-					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue), object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!), name: "README.md"),
+					"README.md": Tree.Entry(attributes: Int32(GIT_FILEMODE_BLOB.rawValue),
+					                        object: .Blob(OID(string: "41078396f5187daed5f673e4a13b185bbad71fba")!),
+					                        name: "README.md"),
 				]
 				expect(tree.entries).to(equal(entries))
 			}

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -74,7 +74,7 @@ class RepositorySpec: QuickSpec {
 
 			it("should be able to clone a remote repository") {
 				let remoteRepoURL = URL(string: "https://github.com/libgit2/libgit2.github.com.git")
-				let localURL =  self.temporaryURL(forPurpose: "public-remote-clone")
+				let localURL = self.temporaryURL(forPurpose: "public-remote-clone")
 				let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL)
 
 				expect(cloneResult).to(haveSucceeded())
@@ -99,7 +99,7 @@ class RepositorySpec: QuickSpec {
 
 				it("should be able to clone a remote repository requiring credentials") {
 					let remoteRepoURL = URL(string: privateRepo)
-					let localURL =  self.temporaryURL(forPurpose: "private-remote-clone")
+					let localURL = self.temporaryURL(forPurpose: "private-remote-clone")
 					let credentials = Credentials.SSHMemory(username: gitUsername,
 					                                        publicKey: publicKey,
 					                                        privateKey: privateKey,

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -91,15 +91,21 @@ class RepositorySpec: QuickSpec {
 
 			let env = ProcessInfo.processInfo.environment
 
-			if let privateRepo = env["SG2TestPrivateRepo"], let gitUsername = env["SG2TestUsername"], let publicKey = env["SG2TestPublicKey"],
-				let privateKey = env["SG2TestPrivateKey"], let passphrase = env["SG2TestPassphrase"] {
+			if let privateRepo = env["SG2TestPrivateRepo"],
+				let gitUsername = env["SG2TestUsername"],
+				let publicKey = env["SG2TestPublicKey"],
+				let privateKey = env["SG2TestPrivateKey"],
+				let passphrase = env["SG2TestPassphrase"] {
 
 				it("should be able to clone a remote repository requiring credentials") {
 					let remoteRepoURL = URL(string: privateRepo)
 					let localURL =  self.temporaryURL(forPurpose: "private-remote-clone")
+					let credentials = Credentials.SSHMemory(username: gitUsername,
+					                                        publicKey: publicKey,
+					                                        privateKey: privateKey,
+					                                        passphrase: passphrase)
 
-					let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL,
-						credentials: .SSHMemory(username: gitUsername, publicKey: publicKey, privateKey: privateKey, passphrase: passphrase))
+					let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL, credentials: credentials)
 
 					expect(cloneResult).to(haveSucceeded())
 

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -570,7 +570,7 @@ class RepositorySpec: QuickSpec {
 				let oid = OID(string: "315b3f344221db91ddc54b269f3c9af422da0f2e")!
 				expect(repo.HEAD().value?.shortName).to(equal("master"))
 
-				expect(repo.checkout(oid, strategy: .None, progress: { (path, completedSteps, totalSteps) -> Void in
+				expect(repo.checkout(oid, strategy: .None, progress: { (_, completedSteps, totalSteps) -> Void in
 					expect(completedSteps).to(beLessThanOrEqualTo(totalSteps))
 				})).to(haveSucceeded())
 


### PR DESCRIPTION
Update the configuration and sources for new rules in SwiftLint 0.15. Also, re-enable the `line_length` rule and wrap lines longer than 120 characters.