### PR TITLE
Improvements for SwiftLint 0.18

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - force_cast
   - force_try
   - function_body_length
+  - identifier_name
   - type_body_length
 
 opt_in_rules:
@@ -12,7 +13,9 @@ opt_in_rules:
   - conditional_returns_on_newline
   - empty_count
   - explicit_init
+  - fatal_error_message
   - first_where
+  - implicitly_unwrapped_optional
   - overridden_super_call
   - private_outlet
   - prohibited_super_call

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: xcode8.2
+osx_image: xcode8.3
 
 sudo: false # Enable container-based builds
 

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -729,7 +729,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint is not installed\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --lenient\nelse\n    echo \"warning: SwiftLint is not installed\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1180,6 +1180,7 @@
 				C9CE0DD51E0710BD0053205D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -15,7 +15,7 @@ public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void
 /// Helper function used as the libgit2 progress callback in git_checkout_options.
 /// This is a function with a type signature of git_checkout_progress_cb.
 private func checkoutProgressCallback(path: UnsafePointer<Int8>?, completedSteps: Int, totalSteps: Int,
-                                      payload: UnsafeMutableRawPointer?) -> Void {
+                                      payload: UnsafeMutableRawPointer?) {
 	if let payload = payload {
 		let buffer = payload.assumingMemoryBound(to: CheckoutProgressBlock.self)
 		let block: CheckoutProgressBlock


### PR DESCRIPTION
When attempting to build SwiftGit2 via Carthage, SwiftLint caused the build to fail because of new linter rules added after the project was configured to use SwiftLint. This PR changes the SwiftLint build phase to use the `--lenient` flag, which will cause the linter to generate only warnings, not errors.

This PR also...
 - fixes a small lint issue with explicitly returning Void from a function.
 - enables several new linter rules which seem helpful.
 - disables the `identifier_name` rule, which was complaining about enum cases not beginning with lowercase letters. (See #87)
 - configures Travis to use the Xcode 8.3 image, which has SwiftLint 0.18.1 installed.

Fixes #85.