### PR TITLE
Fix header interface generation

### DIFF
--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 			baseConfigurationReference = BEB31F501A0D75EE00F525B9 /* iOS-Framework.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					External/libgit2/include,
+					"$(SRCROOT)/External/libgit2/include",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;
@@ -868,7 +868,7 @@
 			baseConfigurationReference = BEB31F501A0D75EE00F525B9 /* iOS-Framework.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					External/libgit2/include,
+					"$(SRCROOT)/External/libgit2/include",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;
@@ -988,7 +988,7 @@
 			baseConfigurationReference = BEB31F561A0D75EE00F525B9 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					External/libgit2/include,
+					"$(SRCROOT)/External/libgit2/include",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;
@@ -1016,7 +1016,7 @@
 			baseConfigurationReference = BEB31F561A0D75EE00F525B9 /* Mac-Framework.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					External/libgit2/include,
+					"$(SRCROOT)/External/libgit2/include",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;


### PR DESCRIPTION
https://twitter.com/benlangmuir/status/943239006627684352

> The problem seems to be related to relative search paths/working directory. I knew we had issues there for Swift files, but I didn't expect it for header-interface generation.
>
> Workaround: in the xcode project, change the first path in HEADER_SEARCH_PATHS:
> ```
> - External/libgit2/include
> + $(SRCROOT)/External/libgit2/include
> ```