### PR TITLE
add Repository.isValid

### DIFF
--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -931,4 +931,21 @@ final public class Repository {
 
 		return .success(returnArray)
 	}
+
+	// MARK: - Validity/Existence Check
+
+	/// - returns: `.success(true)` iff there is a git repository at `url`, `.success(false)` if there isn't, and a `.failure` if there's been an error.
+	public static func isValid(url: URL) -> Result<Bool, NSError> {
+		var pointer: OpaquePointer? = nil
+
+		let result = url.withUnsafeFileSystemRepresentation {
+			git_repository_open_ext(&pointer, $0, GIT_REPOSITORY_OPEN_NO_SEARCH.rawValue, nil)
+		}
+
+		switch result {
+		case GIT_ENOTFOUND.rawValue: return .success(false)
+		case GIT_OK.rawValue: return .success(true)
+		default: return .failure(NSError(gitError: result, pointOfFailure: "git_repository_open_ext"))
+		}
+	}
 }

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -934,18 +934,23 @@ final public class Repository {
 
 	// MARK: - Validity/Existence Check
 
-	/// - returns: `.success(true)` iff there is a git repository at `url`, `.success(false)` if there isn't, and a `.failure` if there's been an error.
+	/// - returns: `.success(true)` iff there is a git repository at `url`,
+	///   `.success(false)` if there isn't,
+	///   and a `.failure` if there's been an error.
 	public static func isValid(url: URL) -> Result<Bool, NSError> {
-		var pointer: OpaquePointer? = nil
+		var pointer: OpaquePointer?
 
 		let result = url.withUnsafeFileSystemRepresentation {
 			git_repository_open_ext(&pointer, $0, GIT_REPOSITORY_OPEN_NO_SEARCH.rawValue, nil)
 		}
 
 		switch result {
-		case GIT_ENOTFOUND.rawValue: return .success(false)
-		case GIT_OK.rawValue: return .success(true)
-		default: return .failure(NSError(gitError: result, pointOfFailure: "git_repository_open_ext"))
+		case GIT_ENOTFOUND.rawValue:
+			return .success(false)
+		case GIT_OK.rawValue:
+			return .success(true)
+		default:
+			return .failure(NSError(gitError: result, pointOfFailure: "git_repository_open_ext"))
 		}
 	}
 }

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -27,6 +27,46 @@ class RepositorySpec: QuickSpec {
 			}
 		}
 
+		describe("Repository.Type.isValid(url:)") {
+			it("should return true if the repo exists") {
+				guard let repositoryURL = Fixtures.simpleRepository.directoryURL else {
+					fail("Fixture setup broken: Repository does not exist"); return
+				}
+
+				let result = Repository.isValid(url: repositoryURL)
+
+				expect(result.error).to(beNil())
+
+				if case .success(let isValid) = result {
+					expect(isValid).to(beTruthy())
+				}
+			}
+
+			it("should return false if the directory does not contain a repo") {
+				let tmpURL = URL(fileURLWithPath: "/dev/null")
+				let result = Repository.isValid(url: tmpURL)
+
+				expect(result.error).to(beNil())
+
+				if case .success(let isValid) = result {
+					expect(isValid).to(beFalsy())
+				}
+			}
+
+			it("should return error if .git is not readable") {
+				let localURL = self.temporaryURL(forPurpose: "git-isValid-unreadable").appendingPathComponent(".git")
+				let nonReadablePermissions: [String: Any] = [FileAttributeKey.posixPermissions.rawValue: 0o077]
+				try! FileManager.default.createDirectory(
+					at: localURL,
+					withIntermediateDirectories: true,
+					attributes: nonReadablePermissions)
+				let result = Repository.isValid(url: localURL)
+
+				expect(result.value).to(beNil())
+				expect(result.error).notTo(beNil())
+			}
+		}
+
 		describe("Repository.Type.create(at:)") {
 			it("should create a new repo at the specified location") {
 				let localURL = self.temporaryURL(forPurpose: "local-create")


### PR DESCRIPTION
Adds a boolean check that some libgit2 bindings have, too, to avoid the overhead of dealing with the real "open" return values.