### PR TITLE
SwiftLint fixes and updates

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+# Configuration for Hound (https://houndci.com)
+
+swiftlint:
+  config_file: .swiftlint.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,24 +8,59 @@ disabled_rules:
   - type_body_length
 
 opt_in_rules:
+  - array_init
   - attributes
   - closure_end_indentation
   - closure_spacing
+  - collection_alignment
   - conditional_returns_on_newline
+  - contains_over_first_not_nil
   - convenience_type
+  - discouraged_object_literal
+  - discouraged_optional_boolean
+  - discouraged_optional_collection
   - empty_count
+  - empty_string
+  - empty_xctest_method
+  - explicit_enum_raw_value
   - explicit_init
+  - extension_access_modifier
+  - fallthrough
   - fatal_error_message
   - first_where
+  - function_default_parameter_at_end
+  - identical_operands
   - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - last_where
+  - legacy_random
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
   - modifier_order
   - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - nslocalizedstring_key
   - overridden_super_call
+  - override_in_extension
+  - private_action
   - private_outlet
   - prohibited_super_call
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
   - redundant_nil_coalescing
+  - sorted_first_last
+  - strict_fileprivate
   - switch_case_on_newline
+  - toggle_bool
+  - unavailable_function
+  - untyped_error_in_catch
+  - unused_import
+  - unused_private_declaration
   - vertical_parameter_alignment_on_call
+  - xct_specific_matcher
+  - yoda_condition
 
 excluded:
   - Carthage

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ opt_in_rules:
   - fatal_error_message
   - first_where
   - implicitly_unwrapped_optional
+  - modifier_order
   - overridden_super_call
   - private_outlet
   - prohibited_super_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,7 @@ opt_in_rules:
   - prohibited_super_call
   - redundant_nil_coalescing
   - switch_case_on_newline
+  - vertical_parameter_alignment_on_call
 
 excluded:
   - Carthage

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ opt_in_rules:
   - closure_end_indentation
   - closure_spacing
   - conditional_returns_on_newline
+  - convenience_type
   - empty_count
   - explicit_init
   - fatal_error_message

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,8 @@ disabled_rules:
   - force_cast
   - force_try
   - function_body_length
+  - identifier_name
+  - redundant_optional_initialization
   - type_body_length
 
 opt_in_rules:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,7 @@ opt_in_rules:
   - first_where
   - implicitly_unwrapped_optional
   - modifier_order
+  - multiline_arguments
   - overridden_super_call
   - private_outlet
   - prohibited_super_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,9 @@ excluded:
   - Carthage
   - External
 
+line_length:
+  ignores_function_declarations: true
+
 trailing_comma:
   mandatory_comma: true
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,6 +50,7 @@ opt_in_rules:
   - quick_discouraged_focused_test
   - quick_discouraged_pending_test
   - redundant_nil_coalescing
+  - redundant_type_annotation
   - sorted_first_last
   - strict_fileprivate
   - switch_case_on_newline

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -59,8 +59,8 @@ public class CommitIterator: IteratorProtocol, Sequence {
 			var unsafeCommit: OpaquePointer? = nil
 			let lookupGitResult = git_commit_lookup(&unsafeCommit, repo.pointer, &oid)
 			guard lookupGitResult == GIT_OK.rawValue,
-			      let unwrapCommit = unsafeCommit else {
-				return Result.failure(NSError(gitError: lookupGitResult, pointOfFailure: "git_commit_lookup"))
+				let unwrapCommit = unsafeCommit else {
+					return Result.failure(NSError(gitError: lookupGitResult, pointOfFailure: "git_commit_lookup"))
 			}
 			let result: Element = Result.success(Commit(unwrapCommit))
 			git_commit_free(unsafeCommit)

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -59,7 +59,7 @@ public struct Signature {
 	func makeUnsafeSignature() -> Result<UnsafeMutablePointer<git_signature>, NSError> {
 		var signature: UnsafeMutablePointer<git_signature>? = nil
 		let time = git_time_t(self.time.timeIntervalSince1970)	// Unix epoch time
-		let offset: Int32 = Int32(timeZone.secondsFromGMT(for: self.time) / 60)
+		let offset = Int32(timeZone.secondsFromGMT(for: self.time) / 60)
 		let signatureResult = git_signature_new(&signature, name, email, time, offset)
 		guard signatureResult == GIT_OK.rawValue, let signatureUnwrap = signature else {
 			let err = NSError(gitError: signatureResult, pointOfFailure: "git_signature_new")

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -704,8 +704,6 @@ final public class Repository {
 	// MARK: - Diffs
 
 	public func diff(for commit: Commit) -> Result<Diff, NSError> {
-		typealias Delta = Diff.Delta
-
 		guard !commit.parents.isEmpty else {
 			// Initial commit in a repository
 			return self.diff(from: nil, to: commit.oid)
@@ -847,8 +845,7 @@ final public class Repository {
 	}
 
 	private func processDiffDeltas(_ diffResult: OpaquePointer) -> Result<[Diff.Delta], NSError> {
-		typealias Delta = Diff.Delta
-		var returnDict = [Delta]()
+		var returnDict = [Diff.Delta]()
 
 		let count = git_diff_num_deltas(diffResult)
 

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -95,7 +95,7 @@ private func cloneOptions(bare: Bool = false, localClone: Bool = false, fetchOpt
 }
 
 /// A git repository.
-final public class Repository {
+public final class Repository {
 
 	// MARK: - Creating Repositories
 
@@ -104,7 +104,7 @@ final public class Repository {
 	/// URL - The URL of the repository.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
-	class public func create(at url: URL) -> Result<Repository, NSError> {
+	public class func create(at url: URL) -> Result<Repository, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = url.withUnsafeFileSystemRepresentation {
 			git_repository_init(&pointer, $0, 0)
@@ -123,7 +123,7 @@ final public class Repository {
 	/// URL - The URL of the repository.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
-	class public func at(_ url: URL) -> Result<Repository, NSError> {
+	public class func at(_ url: URL) -> Result<Repository, NSError> {
 		var pointer: OpaquePointer? = nil
 		let result = url.withUnsafeFileSystemRepresentation {
 			git_repository_open(&pointer, $0)
@@ -148,7 +148,7 @@ final public class Repository {
 	/// checkoutProgress - A block that's called with the progress of the checkout.
 	///
 	/// Returns a `Result` with a `Repository` or an error.
-	class public func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
+	public class func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
 	                        credentials: Credentials = .default, checkoutStrategy: CheckoutStrategy = .Safe,
 	                        checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
 			var options = cloneOptions(

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -152,7 +152,8 @@ public final class Repository {
 	                        credentials: Credentials = .default, checkoutStrategy: CheckoutStrategy = .Safe,
 	                        checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
 			var options = cloneOptions(
-				bare: bare, localClone: localClone,
+				bare: bare,
+				localClone: localClone,
 				fetchOptions: fetchOptions(credentials: credentials),
 				checkoutOptions: checkoutOptions(strategy: checkoutStrategy, progress: checkoutProgress))
 

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -151,24 +151,24 @@ public final class Repository {
 	public class func clone(from remoteURL: URL, to localURL: URL, localClone: Bool = false, bare: Bool = false,
 	                        credentials: Credentials = .default, checkoutStrategy: CheckoutStrategy = .Safe,
 	                        checkoutProgress: CheckoutProgressBlock? = nil) -> Result<Repository, NSError> {
-			var options = cloneOptions(
-				bare: bare,
-				localClone: localClone,
-				fetchOptions: fetchOptions(credentials: credentials),
-				checkoutOptions: checkoutOptions(strategy: checkoutStrategy, progress: checkoutProgress))
+		var options = cloneOptions(
+			bare: bare,
+			localClone: localClone,
+			fetchOptions: fetchOptions(credentials: credentials),
+			checkoutOptions: checkoutOptions(strategy: checkoutStrategy, progress: checkoutProgress))
 
-			var pointer: OpaquePointer? = nil
-			let remoteURLString = (remoteURL as NSURL).isFileReferenceURL() ? remoteURL.path : remoteURL.absoluteString
-			let result = localURL.withUnsafeFileSystemRepresentation { localPath in
-				git_clone(&pointer, remoteURLString, localPath, &options)
-			}
+		var pointer: OpaquePointer? = nil
+		let remoteURLString = (remoteURL as NSURL).isFileReferenceURL() ? remoteURL.path : remoteURL.absoluteString
+		let result = localURL.withUnsafeFileSystemRepresentation { localPath in
+			git_clone(&pointer, remoteURLString, localPath, &options)
+		}
 
-			guard result == GIT_OK.rawValue else {
-				return Result.failure(NSError(gitError: result, pointOfFailure: "git_clone"))
-			}
+		guard result == GIT_OK.rawValue else {
+			return Result.failure(NSError(gitError: result, pointOfFailure: "git_clone"))
+		}
 
-			let repository = Repository(pointer!)
-			return Result.success(repository)
+		let repository = Repository(pointer!)
+		return Result.success(repository)
 	}
 
 	// MARK: - Initializers

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -763,14 +763,14 @@ final public class Repository {
 
 		var diff: OpaquePointer? = nil
 		let diffResult = git_diff_tree_to_tree(&diff,
-																					 self.pointer,
-																					 oldTree,
-																					 newTree,
-																					 nil)
+		                                       self.pointer,
+		                                       oldTree,
+		                                       newTree,
+		                                       nil)
 
 		guard diffResult == GIT_OK.rawValue else {
 			return transform(.failure(NSError(gitError: diffResult,
-															pointOfFailure: "git_diff_tree_to_tree")))
+			                                  pointOfFailure: "git_diff_tree_to_tree")))
 		}
 
 		return transform(Result<OpaquePointer, NSError>.success(diff!))
@@ -802,30 +802,30 @@ final public class Repository {
 			return withGitObjects([oldTree!.oid, newTree!.oid], type: GIT_OBJ_TREE) { objects in
 				var diff: OpaquePointer? = nil
 				let diffResult = git_diff_tree_to_tree(&diff,
-																							 self.pointer,
-																							 objects[0],
-																							 objects[1],
-																							 nil)
+				                                       self.pointer,
+				                                       objects[0],
+				                                       objects[1],
+				                                       nil)
 				return processTreeToTreeDiff(diffResult, diff: diff)
 			}
 		} else if let tree = oldTree {
 			return withGitObject(tree.oid, type: GIT_OBJ_TREE, transform: { tree in
 				var diff: OpaquePointer? = nil
 				let diffResult = git_diff_tree_to_tree(&diff,
-																							 self.pointer,
-																							 tree,
-																							 nil,
-																							 nil)
+				                                       self.pointer,
+				                                       tree,
+				                                       nil,
+				                                       nil)
 				return processTreeToTreeDiff(diffResult, diff: diff)
 			})
 		} else if let tree = newTree {
 			return withGitObject(tree.oid, type: GIT_OBJ_TREE, transform: { tree in
 				var diff: OpaquePointer? = nil
 				let diffResult = git_diff_tree_to_tree(&diff,
-																							 self.pointer,
-																							 nil,
-																							 tree,
-																							 nil)
+				                                       self.pointer,
+				                                       nil,
+				                                       tree,
+				                                       nil)
 				return processTreeToTreeDiff(diffResult, diff: diff)
 			})
 		}
@@ -836,7 +836,7 @@ final public class Repository {
 	private func processTreeToTreeDiff(_ diffResult: Int32, diff: OpaquePointer?) -> Result<Diff, NSError> {
 		guard diffResult == GIT_OK.rawValue else {
 			return .failure(NSError(gitError: diffResult,
-															pointOfFailure: "git_diff_tree_to_tree"))
+			                        pointOfFailure: "git_diff_tree_to_tree"))
 		}
 
 		let diffObj = Diff(diff!)

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -15,7 +15,7 @@ final class Fixtures {
 	// MARK: Lifecycle
 
 	class var sharedInstance: Fixtures {
-		struct Singleton {
+		enum Singleton {
 			static let instance = Fixtures()
 		}
 		return Singleton.instance

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -685,43 +685,43 @@ class RepositorySpec: QuickSpec {
 				expect(commitMessages).to(equal(expectedMessages))
 			}
 		}
-		
+
 		describe("Repository.add") {
 			it("Should add the modification under a path") {
 				let repo = Fixtures.simpleRepository
 				let branch = repo.localBranch(named: "master").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None).error).to(beNil())
-				
+
 				// make a change to README
 				let readmeURL = repo.directoryURL!.appendingPathComponent("README.md")
 				let readmeData = try! Data(contentsOf: readmeURL)
 				defer { try! readmeData.write(to: readmeURL) }
-				
+
 				try! "different".data(using: .utf8)?.write(to: readmeURL)
-				
+
 				let status = repo.status()
 				expect(status.value?.count).to(equal(1))
 				expect(status.value!.first!.status).to(equal(.workTreeModified))
-				
+
 				expect(repo.add(path: "README.md").error).to(beNil())
-				
+
 				let newStatus = repo.status()
 				expect(newStatus.value?.count).to(equal(1))
 				expect(newStatus.value!.first!.status).to(equal(.indexModified))
 			}
-			
+
 			it("Should add an untracked file under a path") {
 				let repo = Fixtures.simpleRepository
 				let branch = repo.localBranch(named: "master").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None).error).to(beNil())
-				
+
 				// make a change to README
 				let untrackedURL = repo.directoryURL!.appendingPathComponent("untracked")
 				try! "different".data(using: .utf8)?.write(to: untrackedURL)
 				defer { try! FileManager.default.removeItem(at: untrackedURL) }
-				
+
 				expect(repo.add(path: ".").error).to(beNil())
-				
+
 				let newStatus = repo.status()
 				expect(newStatus.value?.count).to(equal(1))
 				expect(newStatus.value!.first!.status).to(equal(.indexNew))
@@ -733,13 +733,13 @@ class RepositorySpec: QuickSpec {
 				let repo = Fixtures.simpleRepository
 				let branch = repo.localBranch(named: "master").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None).error).to(beNil())
-				
+
 				// make a change to README
 				let untrackedURL = repo.directoryURL!.appendingPathComponent("untrackedtest")
 				try! "different".data(using: .utf8)?.write(to: untrackedURL)
-				
+
 				expect(repo.add(path: ".").error).to(beNil())
-				
+
 				let signature = Signature(
 					name: "swiftgit2",
 					email: "foobar@example.com",
@@ -753,17 +753,17 @@ class RepositorySpec: QuickSpec {
 				expect(repo.commits(in: updatedBranch).next()?.value?.committer).to(equal(signature))
 				expect(repo.commits(in: updatedBranch).next()?.value?.message).to(equal("\(message)\n"))
 				expect(repo.commits(in: updatedBranch).next()?.value?.oid.description).to(equal("7d6b2d7492f29aee48022387f96dbfe996d435fe"))
-				
+
 				// should be clean now
 				let newStatus = repo.status()
 				expect(newStatus.value?.count).to(equal(0))
 			}
 		}
-		
+
 		describe("Repository.status") {
 			it("Should accurately report status for repositories with no status") {
 				let expectedCount = 0
-				
+
 				let repo = Fixtures.mantleRepository
 				let branch = repo.localBranch(named: "master").value!
 				expect(repo.checkout(branch, strategy: CheckoutStrategy.None).error).to(beNil())

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -151,9 +151,9 @@ class RepositorySpec: QuickSpec {
 					let remoteRepoURL = URL(string: privateRepo)
 					let localURL = self.temporaryURL(forPurpose: "private-remote-clone")
 					let credentials = Credentials.sshMemory(username: gitUsername,
-						publicKey: publicKey,
-						privateKey: privateKey,
-						passphrase: passphrase)
+					                                        publicKey: publicKey,
+					                                        privateKey: privateKey,
+					                                        passphrase: passphrase)
 
 					let cloneResult = Repository.clone(from: remoteRepoURL!, to: localURL, credentials: credentials)
 

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -752,7 +752,8 @@ class RepositorySpec: QuickSpec {
 				expect(repo.commits(in: updatedBranch).next()?.value?.author).to(equal(signature))
 				expect(repo.commits(in: updatedBranch).next()?.value?.committer).to(equal(signature))
 				expect(repo.commits(in: updatedBranch).next()?.value?.message).to(equal("\(message)\n"))
-				expect(repo.commits(in: updatedBranch).next()?.value?.oid.description).to(equal("7d6b2d7492f29aee48022387f96dbfe996d435fe"))
+				expect(repo.commits(in: updatedBranch).next()?.value?.oid.description)
+					.to(equal("7d6b2d7492f29aee48022387f96dbfe996d435fe"))
 
 				// should be clean now
 				let newStatus = repo.status()

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -11,6 +11,8 @@ import SwiftGit2
 import Nimble
 import Quick
 
+// swiftlint:disable cyclomatic_complexity
+
 class RepositorySpec: QuickSpec {
 	override func spec() {
 		describe("Repository.Type.at(_:)") {


### PR DESCRIPTION
This PR addresses the ~60 issues currently reported by SwiftLint. The issues that required minimal changes to the code – whitespace and line wrapping, mostly – have been fixed, and two SwiftLint rules have been (for now) disabled since the code changes required to address them were more invasive.

I've also enabled various new SwiftLint rules that seem helpful, and cleaned up a few cases where the project wasn't already fully following those patterns.

After these changes are merged, the SwiftLint build phase should report no issues. To help maintain that, I've added a [Hound configuration for SwiftLint](http://help.houndci.com/configuration/swiftlint).