### PR TITLE
Simplify Equatable and Hashable implementations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,6 +52,7 @@ opt_in_rules:
   - redundant_nil_coalescing
   - redundant_type_annotation
   - sorted_first_last
+  - static_operator
   - strict_fileprivate
   - switch_case_on_newline
   - toggle_bool

--- a/SwiftGit2/Libgit2.swift
+++ b/SwiftGit2/Libgit2.swift
@@ -8,10 +8,6 @@
 
 import libgit2
 
-func == (lhs: git_otype, rhs: git_otype) -> Bool {
-	return lhs.rawValue == rhs.rawValue
-}
-
 extension git_strarray {
 	func filter(_ isIncluded: (String) -> Bool) -> [String] {
 		return map { $0 }.filter(isIncluded)

--- a/SwiftGit2/OID.swift
+++ b/SwiftGit2/OID.swift
@@ -62,10 +62,10 @@ extension OID: Hashable {
 			hasher.combine(bytes: $0)
 		}
 	}
-}
 
-public func == (lhs: OID, rhs: OID) -> Bool {
-	var left = lhs.oid
-	var right = rhs.oid
-	return git_oid_cmp(&left, &right) == 0
+	public static func == (lhs: OID, rhs: OID) -> Bool {
+		var left = lhs.oid
+		var right = rhs.oid
+		return git_oid_cmp(&left, &right) == 0
+	}
 }

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -131,7 +131,7 @@ public struct Tree: ObjectType {
 	public static let type = GIT_OBJ_TREE
 
 	/// An entry in a `Tree`.
-	public struct Entry {
+	public struct Entry: Hashable {
 		/// The entry's UNIX file attributes.
 		public let attributes: Int32
 
@@ -176,24 +176,10 @@ public struct Tree: ObjectType {
 	}
 }
 
-extension Tree.Entry: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(attributes)
-		hasher.combine(object)
-		hasher.combine(name)
-	}
-}
-
 extension Tree.Entry: CustomStringConvertible {
 	public var description: String {
 		return "\(attributes) \(object) \(name)"
 	}
-}
-
-public func == (lhs: Tree.Entry, rhs: Tree.Entry) -> Bool {
-	return lhs.attributes == rhs.attributes
-		&& lhs.object == rhs.object
-		&& lhs.name == rhs.name
 }
 
 extension Tree: Hashable {

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -83,13 +83,6 @@ extension Signature: Hashable {
 	}
 }
 
-public func == (lhs: Signature, rhs: Signature) -> Bool {
-	return lhs.name == rhs.name
-		&& lhs.email == rhs.email
-		&& lhs.time == rhs.time
-		&& lhs.timeZone == rhs.timeZone
-}
-
 /// A git commit.
 public struct Commit: ObjectType, Hashable {
 	public static let type = GIT_OBJ_COMMIT

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -25,6 +25,12 @@ public func == <O: ObjectType>(lhs: O, rhs: O) -> Bool {
 	return lhs.oid == rhs.oid
 }
 
+public extension ObjectType {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(oid)
+	}
+}
+
 public struct Signature {
 	/// The name of the person.
 	public let name: String
@@ -85,7 +91,7 @@ public func == (lhs: Signature, rhs: Signature) -> Bool {
 }
 
 /// A git commit.
-public struct Commit: ObjectType {
+public struct Commit: ObjectType, Hashable {
 	public static let type = GIT_OBJ_COMMIT
 
 	/// The OID of the commit.
@@ -120,14 +126,8 @@ public struct Commit: ObjectType {
 	}
 }
 
-extension Commit: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
-	}
-}
-
 /// A git tree.
-public struct Tree: ObjectType {
+public struct Tree: ObjectType, Hashable {
 	public static let type = GIT_OBJ_TREE
 
 	/// An entry in a `Tree`.
@@ -182,14 +182,8 @@ extension Tree.Entry: CustomStringConvertible {
 	}
 }
 
-extension Tree: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
-	}
-}
-
 /// A git blob.
-public struct Blob: ObjectType {
+public struct Blob: ObjectType, Hashable {
 	public static let type = GIT_OBJ_BLOB
 
 	/// The OID of the blob.
@@ -207,14 +201,8 @@ public struct Blob: ObjectType {
 	}
 }
 
-extension Blob: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
-	}
-}
-
 /// An annotated git tag.
-public struct Tag: ObjectType {
+public struct Tag: ObjectType, Hashable {
 	public static let type = GIT_OBJ_TAG
 
 	/// The OID of the tag.
@@ -240,11 +228,5 @@ public struct Tag: ObjectType {
 		name = String(validatingUTF8: git_tag_name(pointer))!
 		tagger = Signature(git_tag_tagger(pointer).pointee)
 		message = String(validatingUTF8: git_tag_message(pointer))!
-	}
-}
-
-extension Tag: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
 	}
 }

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -21,11 +21,11 @@ public protocol ObjectType {
 	init(_ pointer: OpaquePointer)
 }
 
-public func == <O: ObjectType>(lhs: O, rhs: O) -> Bool {
-	return lhs.oid == rhs.oid
-}
-
 public extension ObjectType {
+	static func == (lhs: Self, rhs: Self) -> Bool {
+		return lhs.oid == rhs.oid
+	}
+
 	func hash(into hasher: inout Hasher) {
 		hasher.combine(oid)
 	}

--- a/SwiftGit2/Pointers.swift
+++ b/SwiftGit2/Pointers.swift
@@ -21,6 +21,12 @@ public func == <P: PointerType>(lhs: P, rhs: P) -> Bool {
 	return lhs.oid == rhs.oid && lhs.type.rawValue == rhs.type.rawValue
 }
 
+public extension PointerType {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(oid)
+	}
+}
+
 /// A pointer to a git object.
 public enum Pointer: PointerType {
 	case commit(OID)
@@ -71,12 +77,6 @@ public enum Pointer: PointerType {
 	}
 }
 
-extension Pointer: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
-	}
-}
-
 extension Pointer: CustomStringConvertible {
 	public var description: String {
 		switch self {
@@ -101,11 +101,5 @@ public struct PointerTo<T: ObjectType>: PointerType {
 
 	public init(_ oid: OID) {
 		self.oid = oid
-	}
-}
-
-extension PointerTo: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(oid)
 	}
 }

--- a/SwiftGit2/Pointers.swift
+++ b/SwiftGit2/Pointers.swift
@@ -17,11 +17,12 @@ public protocol PointerType: Hashable {
 	var type: git_otype { get }
 }
 
-public func == <P: PointerType>(lhs: P, rhs: P) -> Bool {
-	return lhs.oid == rhs.oid && lhs.type.rawValue == rhs.type.rawValue
-}
-
 public extension PointerType {
+	static func == (lhs: Self, rhs: Self) -> Bool {
+		return lhs.oid == rhs.oid
+			&& lhs.type == rhs.type
+	}
+
 	func hash(into hasher: inout Hasher) {
 		hasher.combine(oid)
 	}

--- a/SwiftGit2/References.swift
+++ b/SwiftGit2/References.swift
@@ -25,6 +25,13 @@ public func ==<T: ReferenceType>(lhs: T, rhs: T) -> Bool {
 		&& lhs.oid == rhs.oid
 }
 
+public extension ReferenceType {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(longName)
+		hasher.combine(oid)
+	}
+}
+
 /// Create a Reference, Branch, or TagReference from a libgit2 `git_reference`.
 internal func referenceWithLibGit2Reference(_ pointer: OpaquePointer) -> ReferenceType {
 	if git_reference_is_branch(pointer) != 0 || git_reference_is_remote(pointer) != 0 {
@@ -37,7 +44,7 @@ internal func referenceWithLibGit2Reference(_ pointer: OpaquePointer) -> Referen
 }
 
 /// A generic reference to a git object.
-public struct Reference: ReferenceType {
+public struct Reference: ReferenceType, Hashable {
 	/// The full name of the reference (e.g., `refs/heads/master`).
 	public let longName: String
 
@@ -56,15 +63,8 @@ public struct Reference: ReferenceType {
 	}
 }
 
-extension Reference: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(longName)
-		hasher.combine(oid)
-	}
-}
-
 /// A git branch.
-public struct Branch: ReferenceType {
+public struct Branch: ReferenceType, Hashable {
 	/// The full name of the reference (e.g., `refs/heads/master`).
 	public let longName: String
 
@@ -122,15 +122,8 @@ public struct Branch: ReferenceType {
 	}
 }
 
-extension Branch: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(longName)
-		hasher.combine(oid)
-	}
-}
-
 /// A git tag reference, which can be either a lightweight tag or a Tag object.
-public enum TagReference: ReferenceType {
+public enum TagReference: ReferenceType, Hashable {
 	/// A lightweight tag, which is just a name and an OID.
 	case lightweight(String, OID)
 
@@ -192,12 +185,5 @@ public enum TagReference: ReferenceType {
 			self = .lightweight(name, OID(oid))
 		}
 		git_object_free(pointer)
-	}
-}
-
-extension TagReference: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(longName)
-		hasher.combine(oid)
 	}
 }

--- a/SwiftGit2/References.swift
+++ b/SwiftGit2/References.swift
@@ -20,12 +20,12 @@ public protocol ReferenceType {
 	var oid: OID { get }
 }
 
-public func ==<T: ReferenceType>(lhs: T, rhs: T) -> Bool {
-	return lhs.longName == rhs.longName
-		&& lhs.oid == rhs.oid
-}
-
 public extension ReferenceType {
+	static func == (lhs: Self, rhs: Self) -> Bool {
+		return lhs.longName == rhs.longName
+			&& lhs.oid == rhs.oid
+	}
+
 	func hash(into hasher: inout Hasher) {
 		hasher.combine(longName)
 		hasher.combine(oid)

--- a/SwiftGit2/Remotes.swift
+++ b/SwiftGit2/Remotes.swift
@@ -9,7 +9,7 @@
 import libgit2
 
 /// A remote in a git repository.
-public struct Remote {
+public struct Remote: Hashable {
 	/// The name of the remote.
 	public let name: String
 
@@ -23,15 +23,4 @@ public struct Remote {
 		name = String(validatingUTF8: git_remote_name(pointer))!
 		URL = String(validatingUTF8: git_remote_url(pointer))!
 	}
-}
-
-extension Remote: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(name)
-		hasher.combine(URL)
-	}
-}
-
-public func == (lhs: Remote, rhs: Remote) -> Bool {
-	return lhs.name == rhs.name && lhs.URL == rhs.URL
 }


### PR DESCRIPTION
- For types where the manual `==` and/or `hash(into:)` implementations were equivalent to what the compiler would synthesize, the explicit implementations have been deleted.
- For protocols with common implementations for all types conforming to the protocol, the implementations have been unified in a protocol extension.
- Several `==`implementations have been converted from free functions to static methods.