### PR TITLE
Default Sequence methods on CommitIterator

### DIFF
--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -67,33 +67,4 @@ public class CommitIterator: IteratorProtocol, Sequence {
 			return result
 		}
 	}
-
-	public func makeIterator() -> CommitIterator {
-		return self
-	}
-
-	public private(set) var underestimatedCount: Int = 0
-	public func map<T>(_ transform: (Result<Commit, NSError>) throws -> T) rethrows -> [T] {
-		var new: [T] = []
-		for item in self {
-			new += [try transform(item)]
-		}
-		return new
-	}
-
-	public func filter(_ isIncluded: (Result<Commit, NSError>) throws -> Bool) rethrows -> [Result<Commit, NSError>] {
-		var new: [Result<Commit, NSError>] = []
-		for item in self {
-			if try isIncluded(item) {
-				new += [item]
-			}
-		}
-		return new
-	}
-
-	public func forEach(_ body: (Result<Commit, NSError>) throws -> Void) rethrows {
-		for item in self {
-			try body(item)
-		}
-	}
 }

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -97,8 +97,8 @@ public class CommitIterator: IteratorProtocol, Sequence {
 		}
 	}
 
-	private func notImplemented(functionName: Any) {
-		assert(false, "CommitIterator does not implement \(functionName)")
+	private func notImplemented(functionName: Any, file: StaticString = #file, line: UInt = #line) {
+		fatalError("CommitIterator does not implement \(functionName)", file: file, line: line)
 	}
 	private init(repo: Repository) {
 		self.repo = repo

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -96,37 +96,4 @@ public class CommitIterator: IteratorProtocol, Sequence {
 			try body(item)
 		}
 	}
-
-	private func notImplemented(functionName: Any, file: StaticString = #file, line: UInt = #line) -> Never {
-		fatalError("CommitIterator does not implement \(functionName)", file: file, line: line)
-	}
-
-	public func dropFirst(_ num: Int) -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: self.dropFirst)
-	}
-
-	public func dropLast(_ num: Int) -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: self.dropLast)
-	}
-
-	public func drop(while predicate: (Result<Commit, NSError>) throws -> Bool) rethrows -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: self.drop)
-	}
-
-	public func prefix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: "prefix(_ maxLength:")
-	}
-
-	public func prefix(while predicate: (Result<Commit, NSError>) throws -> Bool) rethrows -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: "prefix(with predicate:")
-	}
-
-	public func suffix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
-		notImplemented(functionName: self.suffix)
-	}
-
-	public func split(maxSplits: Int, omittingEmptySubsequences: Bool, whereSeparator isSeparator: (Result<Commit, NSError>) throws -> Bool) rethrows -> [AnySequence<Iterator.Element>] {
-		notImplemented(functionName: self.split)
-	}
-
 }

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -97,46 +97,36 @@ public class CommitIterator: IteratorProtocol, Sequence {
 		}
 	}
 
-	private func notImplemented(functionName: Any, file: StaticString = #file, line: UInt = #line) {
+	private func notImplemented(functionName: Any, file: StaticString = #file, line: UInt = #line) -> Never {
 		fatalError("CommitIterator does not implement \(functionName)", file: file, line: line)
-	}
-	private init(repo: Repository) {
-		self.repo = repo
 	}
 
 	public func dropFirst(_ num: Int) -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: self.dropFirst)
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func dropLast(_ num: Int) -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: self.dropLast)
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func drop(while predicate: (Result<Commit, NSError>) throws -> Bool) rethrows -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: self.drop)
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func prefix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: "prefix(_ maxLength:")
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func prefix(while predicate: (Result<Commit, NSError>) throws -> Bool) rethrows -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: "prefix(with predicate:")
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func suffix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
 		notImplemented(functionName: self.suffix)
-		return AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }
 	}
 
 	public func split(maxSplits: Int, omittingEmptySubsequences: Bool, whereSeparator isSeparator: (Result<Commit, NSError>) throws -> Bool) rethrows -> [AnySequence<Iterator.Element>] {
 		notImplemented(functionName: self.split)
-		return [AnySequence<Iterator.Element> { return CommitIterator(repo: self.repo) }]
 	}
 
 }


### PR DESCRIPTION
The standard library offers default implementations of many Sequence-related methods via protocol extensions. This PR switches `CommitIterator` to use those implementations instead of its own. This is particularly useful for the seven methods that `CommitIterator` exposed publicly but did not properly implement.