### PR TITLE
Switch to the standard library Result type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git
-[submodule "Carthage/Checkouts/Result"]
-	path = Carthage/Checkouts/Result
-	url = https://github.com/antitypical/Result.git
 [submodule "Carthage/Checkouts/ZipArchive"]
 	path = Carthage/Checkouts/ZipArchive
 	url = https://github.com/ZipArchive/ZipArchive.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "antitypical/Result" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.0.0"
 github "ZipArchive/ZipArchive" "v2.1.5"
-github "antitypical/Result" "4.1.0"
 github "jspahrsummers/xcconfigs" "1.0"

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -80,8 +80,8 @@
 		BECB5F6C1A56F1B400999413 /* ReferencesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6B1A56F1B400999413 /* ReferencesSpec.swift */; };
 		BECB5F6E1A57284700999413 /* Remotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6D1A57284700999413 /* Remotes.swift */; };
 		BECB5F701A57286200999413 /* RemotesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6F1A57286200999413 /* RemotesSpec.swift */; };
-		C98A2BA02263E017007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
-		C98A2BA12263E017007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
+		C98A2BA22263FDB9007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
+		C98A2BA32263FDBA007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
 		DA5023A01A969F1A004175D7 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA50239F1A969F1A004175D7 /* Nimble.framework */; };
 		DA5914761A94579000AED74C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914751A94579000AED74C /* Errors.swift */; };
 		DAC8143D1A99749D0063D88C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC8143C1A99749D0063D88C /* Quick.framework */; };
@@ -315,7 +315,6 @@
 				BECB5F691A56F19900999413 /* References.swift */,
 				BECB5F6D1A57284700999413 /* Remotes.swift */,
 				25499A996CA7BD416620A397 /* CommitIterator.swift */,
-				C98A2B9F2263E017007A4E3A /* ResultShims.swift */,
 			);
 			path = SwiftGit2;
 			sourceTree = "<group>";
@@ -339,6 +338,7 @@
 				BECB5F6B1A56F1B400999413 /* ReferencesSpec.swift */,
 				BECB5F6F1A57286200999413 /* RemotesSpec.swift */,
 				BE14AA581A1996B70015B439 /* FixturesSpec.swift */,
+				C98A2B9F2263E017007A4E3A /* ResultShims.swift */,
 				BEB31F331A0D6F7A00F525B9 /* Supporting Files */,
 			);
 			path = SwiftGit2Tests;
@@ -753,7 +753,6 @@
 				232861451F4A3A2E00276D65 /* Diffs.swift in Sources */,
 				621E66A51C72958800A0F352 /* References.swift in Sources */,
 				621E66A61C72958800A0F352 /* Libgit2.swift in Sources */,
-				C98A2BA12263E017007A4E3A /* ResultShims.swift in Sources */,
 				621E66A71C72958800A0F352 /* Pointers.swift in Sources */,
 				621E66A81C72958800A0F352 /* Errors.swift in Sources */,
 				621E66A91C72958800A0F352 /* SwiftGit2.m in Sources */,
@@ -772,6 +771,7 @@
 				621E66BE1C72958D00A0F352 /* Fixtures.swift in Sources */,
 				621E66BF1C72958D00A0F352 /* ReferencesSpec.swift in Sources */,
 				621E66C01C72958D00A0F352 /* OIDSpec.swift in Sources */,
+				C98A2BA32263FDBA007A4E3A /* ResultShims.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -788,7 +788,6 @@
 				232861431F4A3A2E00276D65 /* Diffs.swift in Sources */,
 				BECB5F6A1A56F19900999413 /* References.swift in Sources */,
 				BE36354C1A632C9700D37EC8 /* Libgit2.swift in Sources */,
-				C98A2BA02263E017007A4E3A /* ResultShims.swift in Sources */,
 				BE7A753F1A4A2BCC002DA7E3 /* Pointers.swift in Sources */,
 				DA5914761A94579000AED74C /* Errors.swift in Sources */,
 				BE14AA501A1974010015B439 /* SwiftGit2.m in Sources */,
@@ -807,6 +806,7 @@
 				BE14AA551A1984550015B439 /* Fixtures.swift in Sources */,
 				BECB5F6C1A56F1B400999413 /* ReferencesSpec.swift in Sources */,
 				BE70B3E71A1ACB37002C3F4E /* OIDSpec.swift in Sources */,
+				C98A2BA22263FDB9007A4E3A /* ResultShims.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		621E66C81C72958D00A0F352 /* detached-head.zip in Resources */ = {isa = PBXBuildFile; fileRef = BE0B1C5C1A9978890004726D /* detached-head.zip */; };
 		621E66C91C72958D00A0F352 /* Mantle.zip in Resources */ = {isa = PBXBuildFile; fileRef = BE0991F61A578FB1007D4E6A /* Mantle.zip */; };
 		621E66CA1C72958D00A0F352 /* simple-repository.zip in Resources */ = {isa = PBXBuildFile; fileRef = BE14AA561A198C6E0015B439 /* simple-repository.zip */; };
-		621E66D91C72989A00A0F352 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621E66D81C72989900A0F352 /* Result.framework */; };
 		621E66E61C729D9600A0F352 /* SwiftGit2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621E66B41C72958800A0F352 /* SwiftGit2.framework */; };
 		621E66FE1C72A5FF00A0F352 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 621E66FD1C72A5FF00A0F352 /* libiconv.tbd */; };
 		621E67001C72A60B00A0F352 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 621E66FF1C72A60B00A0F352 /* libz.tbd */; };
@@ -81,7 +80,8 @@
 		BECB5F6C1A56F1B400999413 /* ReferencesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6B1A56F1B400999413 /* ReferencesSpec.swift */; };
 		BECB5F6E1A57284700999413 /* Remotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6D1A57284700999413 /* Remotes.swift */; };
 		BECB5F701A57286200999413 /* RemotesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECB5F6F1A57286200999413 /* RemotesSpec.swift */; };
-		BEE591C71ADF470500534F14 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEE591C61ADF470500534F14 /* Result.framework */; };
+		C98A2BA02263E017007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
+		C98A2BA12263E017007A4E3A /* ResultShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A2B9F2263E017007A4E3A /* ResultShims.swift */; };
 		DA5023A01A969F1A004175D7 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA50239F1A969F1A004175D7 /* Nimble.framework */; };
 		DA5914761A94579000AED74C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914751A94579000AED74C /* Errors.swift */; };
 		DAC8143D1A99749D0063D88C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC8143C1A99749D0063D88C /* Quick.framework */; };
@@ -138,7 +138,6 @@
 		25499A996CA7BD416620A397 /* CommitIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommitIterator.swift; sourceTree = "<group>"; };
 		621E66B41C72958800A0F352 /* SwiftGit2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftGit2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		621E66CE1C72958D00A0F352 /* SwiftGit2-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftGit2-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		621E66D81C72989900A0F352 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "Carthage/Checkouts/Result/build/Debug-iphoneos/Result.framework"; sourceTree = "<group>"; };
 		621E66E11C729CE500A0F352 /* libgit2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libgit2.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		621E66EC1C729EB800A0F352 /* libssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		621E66F21C729EBB00A0F352 /* libssh2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libssh2.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -191,7 +190,7 @@
 		BECB5F6B1A56F1B400999413 /* ReferencesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferencesSpec.swift; sourceTree = "<group>"; };
 		BECB5F6D1A57284700999413 /* Remotes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Remotes.swift; sourceTree = "<group>"; };
 		BECB5F6F1A57286200999413 /* RemotesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemotesSpec.swift; sourceTree = "<group>"; };
-		BEE591C61ADF470500534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "../../Library/Developer/Xcode/DerivedData/SwiftGit2-cdzquzvlxdewyddxgdgxjagqvjba/Build/Products/Debug/Result.framework"; sourceTree = "<group>"; };
+		C98A2B9F2263E017007A4E3A /* ResultShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultShims.swift; sourceTree = "<group>"; };
 		DA50239F1A969F1A004175D7 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5914751A94579000AED74C /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		DAC8143C1A99749D0063D88C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../../../Library/Developer/Xcode/DerivedData/SwiftGit2-ezqqkevntxbroughwcioyxqriijk/Build/Products/Debug/Quick.framework"; sourceTree = "<group>"; };
@@ -204,7 +203,6 @@
 			files = (
 				621E67001C72A60B00A0F352 /* libz.tbd in Frameworks */,
 				621E66FE1C72A5FF00A0F352 /* libiconv.tbd in Frameworks */,
-				621E66D91C72989A00A0F352 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,7 +221,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BEE591C71ADF470500534F14 /* Result.framework in Frameworks */,
 				BEB31FA01A0E595600F525B9 /* libz.dylib in Frameworks */,
 				BEB31F9E1A0E595100F525B9 /* libiconv.dylib in Frameworks */,
 			);
@@ -246,7 +243,6 @@
 		621E66D41C72965C00A0F352 /* Mac */ = {
 			isa = PBXGroup;
 			children = (
-				BEE591C61ADF470500534F14 /* Result.framework */,
 				BEB31F9D1A0E595100F525B9 /* libiconv.dylib */,
 				BEB31F9F1A0E595600F525B9 /* libz.dylib */,
 			);
@@ -256,7 +252,6 @@
 		621E66D51C72966000A0F352 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				621E66D81C72989900A0F352 /* Result.framework */,
 				621E66FD1C72A5FF00A0F352 /* libiconv.tbd */,
 				621E66FF1C72A60B00A0F352 /* libz.tbd */,
 			);
@@ -320,6 +315,7 @@
 				BECB5F691A56F19900999413 /* References.swift */,
 				BECB5F6D1A57284700999413 /* Remotes.swift */,
 				25499A996CA7BD416620A397 /* CommitIterator.swift */,
+				C98A2B9F2263E017007A4E3A /* ResultShims.swift */,
 			);
 			path = SwiftGit2;
 			sourceTree = "<group>";
@@ -757,6 +753,7 @@
 				232861451F4A3A2E00276D65 /* Diffs.swift in Sources */,
 				621E66A51C72958800A0F352 /* References.swift in Sources */,
 				621E66A61C72958800A0F352 /* Libgit2.swift in Sources */,
+				C98A2BA12263E017007A4E3A /* ResultShims.swift in Sources */,
 				621E66A71C72958800A0F352 /* Pointers.swift in Sources */,
 				621E66A81C72958800A0F352 /* Errors.swift in Sources */,
 				621E66A91C72958800A0F352 /* SwiftGit2.m in Sources */,
@@ -791,6 +788,7 @@
 				232861431F4A3A2E00276D65 /* Diffs.swift in Sources */,
 				BECB5F6A1A56F19900999413 /* References.swift in Sources */,
 				BE36354C1A632C9700D37EC8 /* Libgit2.swift in Sources */,
+				C98A2BA02263E017007A4E3A /* ResultShims.swift in Sources */,
 				BE7A753F1A4A2BCC002DA7E3 /* Pointers.swift in Sources */,
 				DA5914761A94579000AED74C /* Errors.swift in Sources */,
 				BE14AA501A1974010015B439 /* SwiftGit2.m in Sources */,

--- a/SwiftGit2.xcworkspace/contents.xcworkspacedata
+++ b/SwiftGit2.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "group:SwiftGit2.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Carthage/Checkouts/Quick/Quick.xcodeproj">
    </FileRef>
    <FileRef

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2017 GitHub, Inc. All rights reserved.
 //
 
-import Result
+import Foundation
 import libgit2
 
 public class CommitIterator: IteratorProtocol, Sequence {

--- a/SwiftGit2/Diffs.swift
+++ b/SwiftGit2/Diffs.swift
@@ -5,7 +5,7 @@
 //  Created by Jake Van Alstyne on 8/20/17.
 //  Copyright © 2017 GitHub, Inc. All rights reserved.
 //
-import Foundation
+
 import libgit2
 
 public struct StatusEntry {

--- a/SwiftGit2/OID.swift
+++ b/SwiftGit2/OID.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import Foundation
 import libgit2
 
 /// An identifier for a Git object.

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import libgit2
-import Result
 
 /// A git object.
 public protocol ObjectType {

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -744,23 +744,23 @@ public final class Repository {
 		var oldTree: OpaquePointer? = nil
 		defer { git_object_free(oldTree) }
 		if let oid = oldCommitOid {
-			let result = unsafeTreeForCommitId(oid)
-			guard result.error == nil else {
-				return transform(Result.failure(result.error!))
+			switch unsafeTreeForCommitId(oid) {
+			case .failure(let error):
+				return transform(.failure(error))
+			case .success(let value):
+				oldTree = value
 			}
-
-			oldTree = result.value
 		}
 
 		var newTree: OpaquePointer? = nil
 		defer { git_object_free(newTree) }
 		if let oid = newCommitOid {
-			let result = unsafeTreeForCommitId(oid)
-			guard result.error == nil else {
-				return transform(Result.failure(result.error!))
+			switch unsafeTreeForCommitId(oid) {
+			case .failure(let error):
+				return transform(.failure(error))
+			case .success(let value):
+				newTree = value
 			}
-
-			newTree = result.value
 		}
 
 		var diff: OpaquePointer? = nil
@@ -783,21 +783,23 @@ public final class Repository {
 		assert(oldCommitOid != nil || newCommitOid != nil, "It is an error to pass nil for both the oldOid and newOid")
 
 		var oldTree: Tree? = nil
-		if oldCommitOid != nil {
-			let result = safeTreeForCommitId(oldCommitOid!)
-			guard result.error == nil else {
-				return Result<Diff, NSError>.failure(result.error!)
+		if let oldCommitOid = oldCommitOid {
+			switch safeTreeForCommitId(oldCommitOid) {
+			case .failure(let error):
+				return .failure(error)
+			case .success(let value):
+				oldTree = value
 			}
-			oldTree = result.value
 		}
 
 		var newTree: Tree? = nil
-		if newCommitOid != nil {
-			let result = self.safeTreeForCommitId(newCommitOid!)
-			guard result.error == nil else {
-				return Result<Diff, NSError>.failure(result.error!)
+		if let newCommitOid = newCommitOid {
+			switch safeTreeForCommitId(newCommitOid) {
+			case .failure(let error):
+				return .failure(error)
+			case .success(let value):
+				newTree = value
 			}
-			newTree = result.value!
 		}
 
 		if oldTree != nil && newTree != nil {

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -867,11 +867,7 @@ public final class Repository {
 	private func safeTreeForCommitId(_ oid: OID) -> Result<Tree, NSError> {
 		return withGitObject(oid, type: GIT_OBJ_COMMIT) { commit in
 			let treeId = git_commit_tree_id(commit)
-			let tree = self.tree(OID(treeId!.pointee))
-			guard tree.error == nil else {
-				return .failure(tree.error!)
-			}
-			return tree
+			return tree(OID(treeId!.pointee))
 		}
 	}
 

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Result
 import libgit2
 
 public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void

--- a/SwiftGit2/ResultShims.swift
+++ b/SwiftGit2/ResultShims.swift
@@ -1,0 +1,15 @@
+public extension Result {
+	var value: Success? {
+		guard case .success(let value) = self else {
+			return nil
+		}
+		return value
+	}
+
+	var error: Failure? {
+		guard case .failure(let error) = self else {
+			return nil
+		}
+		return error
+	}
+}

--- a/SwiftGit2Tests/Fixtures/Fixtures.swift
+++ b/SwiftGit2Tests/Fixtures/Fixtures.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import Foundation
 import SwiftGit2
 import ZipArchive
 

--- a/SwiftGit2Tests/OIDSpec.swift
+++ b/SwiftGit2Tests/OIDSpec.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import Result
 import SwiftGit2
 import Nimble
 import Quick

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import Result
 import SwiftGit2
 import Nimble
 import Quick

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import Result
 import SwiftGit2
 import Nimble
 import Quick

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import Result
 import SwiftGit2
 import Nimble
 import Quick

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import Result
 import SwiftGit2
 import Nimble
 import Quick

--- a/SwiftGit2Tests/ResultShims.swift
+++ b/SwiftGit2Tests/ResultShims.swift
@@ -1,4 +1,5 @@
-public extension Result {
+// Once Nimble adds matchers for the Result type, remove these shims and refactor the tests that use them.
+extension Result {
 	var value: Success? {
 		guard case .success(let value) = self else {
 			return nil


### PR DESCRIPTION
Swift 5 added a `Result` enum to the standard library that can be used in place of [antitypical/Result](https://github.com/antitypical/Result).

The only change to the Result type's API, as used but SwiftGit2, is that the new type doesn't have the optional-returning `value` and `error` accessors. In the tests, I've added shims to re-implement those properties until Nimble [adds matchers for the new Result](https://github.com/Quick/Nimble/pull/643). In the library itself, I've refactored the code that used those properties to use switch statements instead. This new approach produces code with fewer force-unwraps, and also revealed places where failure handling was previously implemented incorrectly.