### PR TITLE
fix running single specs

### DIFF
--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -25,7 +25,7 @@ private extension Repository {
 	}
 }
 
-class SignatureSpec: QuickSpec {
+class SignatureSpec: FixturesSpec {
 	override func spec() {
 		describe("Signature(signature)") {
 			it("should initialize its properties") {

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -24,7 +24,7 @@ private extension Repository {
 	}
 }
 
-class ReferenceSpec: QuickSpec {
+class ReferenceSpec: FixturesSpec {
 	override func spec() {
 		describe("Reference(pointer)") {
 			it("should initialize its properties") {

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -24,7 +24,7 @@ private extension Repository {
 	}
 }
 
-class RemoteSpec: QuickSpec {
+class RemoteSpec: FixturesSpec {
 	override func spec() {
 		describe("Remote(pointer)") {
 			it("should initialize its properties") {

--- a/SwiftGit2Tests/RepositorySpec.swift
+++ b/SwiftGit2Tests/RepositorySpec.swift
@@ -12,7 +12,7 @@ import Quick
 
 // swiftlint:disable cyclomatic_complexity
 
-class RepositorySpec: QuickSpec {
+class RepositorySpec: FixturesSpec {
 	override func spec() {
 		describe("Repository.Type.at(_:)") {
 			it("should work if the repo exists") {


### PR DESCRIPTION
Closes #135 

Uses the (to my surprise already existing) `FixturesSpec` as the base class for specs. Now you can pick and run part of the testing suite. Previously, you had to run all tests.