### PR TITLE
Swift Package Manager support without changing dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode/
+.build/
+
 # Xcode
 #
 build/

--- a/SwiftGit2/CheckoutStrategy.swift
+++ b/SwiftGit2/CheckoutStrategy.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 /// The flags defining how a checkout should be performed.
 /// More detail is available in the libgit2 documentation for `git_checkout_strategy_t`.

--- a/SwiftGit2/CommitIterator.swift
+++ b/SwiftGit2/CommitIterator.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-import libgit2
+import Clibgit2
 
 public class CommitIterator: IteratorProtocol, Sequence {
 	public typealias Iterator = CommitIterator

--- a/SwiftGit2/Credentials.swift
+++ b/SwiftGit2/Credentials.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 private class Wrapper<T> {
 	let value: T

--- a/SwiftGit2/Diffs.swift
+++ b/SwiftGit2/Diffs.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 public struct StatusEntry {
 	public var status: Diff.Status

--- a/SwiftGit2/Errors.swift
+++ b/SwiftGit2/Errors.swift
@@ -1,5 +1,5 @@
 import Foundation
-import libgit2
+import Clibgit2
 
 public let libGit2ErrorDomain = "org.libgit2.libgit2"
 

--- a/SwiftGit2/Libgit2.swift
+++ b/SwiftGit2/Libgit2.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 extension git_strarray {
 	func filter(_ isIncluded: (String) -> Bool) -> [String] {

--- a/SwiftGit2/OID.swift
+++ b/SwiftGit2/OID.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 /// An identifier for a Git object.
 public struct OID {

--- a/SwiftGit2/Objects.swift
+++ b/SwiftGit2/Objects.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import libgit2
+import Clibgit2
 
 /// A git object.
 public protocol ObjectType {

--- a/SwiftGit2/Pointers.swift
+++ b/SwiftGit2/Pointers.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 /// A pointer to a git object.
 public protocol PointerType: Hashable {

--- a/SwiftGit2/References.swift
+++ b/SwiftGit2/References.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 /// A reference to a git object.
 public protocol ReferenceType {

--- a/SwiftGit2/Remotes.swift
+++ b/SwiftGit2/Remotes.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 GitHub, Inc. All rights reserved.
 //
 
-import libgit2
+import Clibgit2
 
 /// A remote in a git repository.
 public struct Remote: Hashable {

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import libgit2
+import Clibgit2
 
 public typealias CheckoutProgressBlock = (String?, Int, Int) -> Void
 

--- a/SwiftGit2Tests/ObjectsSpec.swift
+++ b/SwiftGit2Tests/ObjectsSpec.swift
@@ -9,7 +9,7 @@
 import SwiftGit2
 import Nimble
 import Quick
-import libgit2
+import Clibgit2
 
 private extension Repository {
 	func withGitObject<T>(_ oid: OID, transform: (OpaquePointer) -> T) -> T {

--- a/SwiftGit2Tests/ReferencesSpec.swift
+++ b/SwiftGit2Tests/ReferencesSpec.swift
@@ -9,7 +9,7 @@
 import SwiftGit2
 import Nimble
 import Quick
-import libgit2
+import Clibgit2
 
 private extension Repository {
 	func withGitReference<T>(named name: String, transform: (OpaquePointer) -> T) -> T {

--- a/SwiftGit2Tests/RemotesSpec.swift
+++ b/SwiftGit2Tests/RemotesSpec.swift
@@ -9,7 +9,7 @@
 import SwiftGit2
 import Nimble
 import Quick
-import libgit2
+import Clibgit2
 
 private extension Repository {
 	func withGitRemote<T>(named name: String, transform: (OpaquePointer) -> T) -> T {

--- a/libgit2/module.modulemap
+++ b/libgit2/module.modulemap
@@ -1,4 +1,4 @@
-module libgit2 {
+module Clibgit2 {
 	umbrella header "git2.h"
 
 	export *


### PR DESCRIPTION
The urge to support Swift Package Manager comes from the project which added SwiftGit2 as the dependency through SwiftPM.

But there are some problems since current SPM doesn't support managing build configurations in a file. It provides passing flags during invocation which is very cumbersome.

Using Makefile like approach doesn't scale well since the project that uses SwiftGit2 as a dependency will need to implement every single configuration in their project.

Current approach, we can use simple script which reads configuration files and computes it to be passed in SwiftPM invocation. This is utility offered by [SPMCLI](https://github.com/pondok-programmer/spmcli). It helps define configuration in a file and resolves all config in the project so that the maintainer and users are free from rewriting configurations defined in dependecy. SPMCLI also store resolved config so it can be examined later. Note, this is temporary solution until SPM provides nicer way.

Is there any other solution?
Yes, there are some solution. You can use Makefile, Rakefile, Fb buck, Google bazel. They are more powerful but also have disadvantages.

Disadvantages using above approach is we need Python installation and SPMCLI in our $PATH.

### Test
For now the test configuration has been defined in SPMCLI althoug `spmcli test` invocation throws error durint the test. That's a problem to fix, but the xcodeproj test is the remain success.