### PR TITLE
Fix for Swift 5.2

### DIFF
--- a/SwiftGit2/Diffs.swift
+++ b/SwiftGit2/Diffs.swift
@@ -94,7 +94,7 @@ public struct Diff {
 		}
 		public let rawValue: UInt32
 
-		public static let binary     = Flags(rawValue: 0)
+		public static let binary     = Flags([])
 		public static let notBinary  = Flags(rawValue: 1 << 0)
 		public static let validId    = Flags(rawValue: 1 << 1)
 		public static let exists     = Flags(rawValue: 1 << 2)

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -588,7 +588,7 @@ public final class Repository {
 
 	/// Stage the file(s) under the specified path.
 	public func add(path: String) -> Result<(), NSError> {
-                var dirPointer = UnsafeMutablePointer<Int8>(mutating: (path as NSString).utf8String)
+		var dirPointer = UnsafeMutablePointer<Int8>(mutating: (path as NSString).utf8String)
  		var paths = withExtendedLifetime(&dirPointer) {
 			git_strarray(strings: $0, count: 1)
 		}

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -588,9 +588,10 @@ public final class Repository {
 
 	/// Stage the file(s) under the specified path.
 	public func add(path: String) -> Result<(), NSError> {
-		let dir = path
-		var dirPointer = UnsafeMutablePointer<Int8>(mutating: (dir as NSString).utf8String)
-		var paths = git_strarray(strings: &dirPointer, count: 1)
+                var dirPointer = UnsafeMutablePointer<Int8>(mutating: (path as NSString).utf8String)
+ 		var paths = withExtendedLifetime(&dirPointer) {
+			git_strarray(strings: $0, count: 1)
+		}
 		return unsafeIndex().flatMap { index in
 			defer { git_index_free(index) }
 			let addResult = git_index_add_all(index, &paths, 0, nil, nil)


### PR DESCRIPTION
The latest version of this library threw two errors when compiling against the latest version of Swift. It required two changes:
1. The pointer to the path in the `add` method was changed to outlive the call to `init()`
2. The Diff class was throwing an error about `rawValue: 0` creating an empty set. I changed it directly to that to avoid the error.

I am pretty new to Swift so let me know if this is incorrect!