### PR TITLE
Credentials fix for BAD_ACCESS

### DIFF
--- a/SwiftGit2/Credentials.swift
+++ b/SwiftGit2/Credentials.swift
@@ -23,7 +23,7 @@ public enum Credentials {
 	case sshMemory(username: String, publicKey: String, privateKey: String, passphrase: String)
 
 	private static var previouslyUsedPointer: String? = nil
-	internal static func fromPointer(_ pointer: UnsafeMutableRawPointer) -> Credentials {
+	internal static func fromPointer(_ pointer: UnsafeMutableRawPointer) -> Credentials? {
 		// check if we had just seen this pointer
 		if pointer.debugDescription == previouslyUsedPointer {
 			// we have already used this pointer, so it is likely that libgit2

--- a/SwiftGit2/Credentials.swift
+++ b/SwiftGit2/Credentials.swift
@@ -26,12 +26,17 @@ public enum Credentials {
 	internal static func fromPointer(_ pointer: UnsafeMutableRawPointer) -> Credentials {
 		// check if we had just seen this pointer
 		if pointer.debugDescription == previouslyUsedPointer {
-			// we have already used this pointer, so it is likely that libgit2 has already freed the memory and using Unmanaged<>.fromOpaque will result in a BAD_ACCESS crash
+			// we have already used this pointer, so it is likely that libgit2
+			// has already freed the memory and using Unmanaged<>.fromOpaque will
+			// result in a BAD_ACCESS crash
 			return nil
 		} else {
-			// mark that we have used this pointer so that later attempts to use it in this function will be blocked
+			// mark that we have used this pointer so that
+			// later attempts to use it in this function will
+			// be blocked
 			previouslyUsedPointer = pointer.debugDescription
-			// access the pointer and convert it into a Credentials Swift object
+			// access the pointer and convert it into a
+			// Credentials Swift object
 			return Unmanaged<Wrapper<Credentials>>.fromOpaque(UnsafeRawPointer(pointer)).takeRetainedValue().value
 		}
 	}


### PR DESCRIPTION
This is a fix for an old issue: https://github.com/SwiftGit2/SwiftGit2/issues/100

There's a crash caused by accessing the pointer to the creds object after libgit2 frees it. libgit2 also is calling credentialsCallback, so there is no good way to prevent the crash from happening. Interestingly, libgit2 calls the callback twice, and the result of the second one doesn't seem too important. So because we don't have control over how libgit2 chooses to free objects, I just wrote a simple change to prevent the second call of credentialsCallback from accessing the pointer to the creds object.