### PR TITLE
Get Upstream Name for branch

### DIFF
--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -486,6 +486,17 @@ public final class Repository {
 	public func tag(named name: String) -> Result<TagReference, NSError> {
 		return reference(named: "refs/tags/" + name).map { $0 as! TagReference }
 	}
+	
+	/// Returns the name of the upstream branch.
+	public func upstreamName(for branch: Branch) -> String? {
+		var namePointer = git_buf()
+		git_branch_upstream_name(&namePointer, pointer, branch.longName)
+		defer {
+			git_buf_free(&namePointer)
+		}
+
+		return git_buf_contains_nul(&namePointer) == 0 ? String(cString: namePointer.ptr) : nil
+	}
 
 	// MARK: - Working Directory
 


### PR DESCRIPTION
I added a method to the `Repository` struct to get the upstream name of a branch.