### PR TITLE
Loading all commits from a base, not only branch

### DIFF
--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -571,7 +571,15 @@ public final class Repository {
 	/// :param: branch The branch to get all commits from
 	/// :returns: Returns a result with array of branches or the error that occurred
 	public func commits(in branch: Branch) -> CommitIterator {
-		let iterator = CommitIterator(repo: self, root: branch.oid.oid)
+		return commits(from: branch.oid)
+	}
+	
+	/// Load all commits from the given base in topological & time order descending
+	///
+	/// :param: base The oid to get all commits from
+	/// :returns: Returns a result with array of branches or the error that occurred
+	public func commits(from base: OID) -> CommitIterator {
+		let iterator = CommitIterator(repo: self, root: base.oid)
 		return iterator
 	}
 

--- a/SwiftGit2/Repository.swift
+++ b/SwiftGit2/Repository.swift
@@ -573,7 +573,7 @@ public final class Repository {
 	public func commits(in branch: Branch) -> CommitIterator {
 		return commits(from: branch.oid)
 	}
-	
+
 	/// Load all commits from the given base in topological & time order descending
 	///
 	/// :param: base The oid to get all commits from


### PR DESCRIPTION
One Method is added to the Repository class to load commits not only from a branch, but also from a base itself. The method is called:

`commits(from base: OID) -> CommitIterator`