### PR TITLE
Fix Mac ARM framework creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ DerivedData
 *.idea*
 
 External/libgit2*.a
+External/libgit2-mac
 External/ios-openssl
 External/libgit2-ios
 External/libssh2-ios

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -1021,12 +1021,13 @@
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;
 				LIBRARY_SEARCH_PATHS = (
-					External,
+					"External/libgit2-mac",
+					External/,
 					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
 					"-force_load",
-					"External/libgit2-mac.a",
+					"External/libgit2-mac/libgit2-mac.a",
 					/usr/local/lib/libssh2.a,
 					"-lgit2-mac",
 					"-lcrypto",
@@ -1049,12 +1050,13 @@
 				);
 				INFOPLIST_FILE = SwiftGit2/Info.plist;
 				LIBRARY_SEARCH_PATHS = (
-					External,
+					"External/libgit2-mac",
+					External/,
 					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
 					"-force_load",
-					"External/libgit2-mac.a",
+					"External/libgit2-mac/libgit2-mac.a",
 					/usr/local/lib/libssh2.a,
 					"-lgit2-mac",
 					"-lcrypto",

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -1025,10 +1025,10 @@
 					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
-					"-lgit2",
 					"-force_load",
-					External/libgit2.a,
+					"External/libgit2-mac.a",
 					/usr/local/lib/libssh2.a,
+					"-lgit2-mac",
 					"-lcrypto",
 					"-lssl",
 					"-lcurl",
@@ -1053,10 +1053,10 @@
 					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
-					"-lgit2",
 					"-force_load",
-					External/libgit2.a,
+					"External/libgit2-mac.a",
 					/usr/local/lib/libssh2.a,
+					"-lgit2-mac",
 					"-lcrypto",
 					"-lssl",
 					"-lcurl",

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -686,7 +686,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = script/update_libgit2_ios;
+			shellScript = "script/update_libgit2_ios\n";
 		};
 		621E66E81C729EB800A0F352 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -699,7 +699,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = script/update_libssl_ios;
+			shellScript = "script/update_libssl_ios\n";
 		};
 		621E66EE1C729EBB00A0F352 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -725,7 +725,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = script/update_libgit2;
+			shellScript = "script/update_libgit2\n";
 		};
 		C9CE0DD61E0710C20053205D /* Lint Sources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/SwiftGit2.xcodeproj/project.pbxproj
+++ b/SwiftGit2.xcodeproj/project.pbxproj
@@ -1037,6 +1037,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libgit2.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftGit2;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/libgit2";
+				VALID_ARCHS = "arm64 arm64e i386 x86_64\n";
 			};
 			name = Debug;
 		};
@@ -1066,6 +1067,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libgit2.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftGit2;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/libgit2";
+				VALID_ARCHS = "arm64 arm64e i386 x86_64\n";
 			};
 			name = Release;
 		};

--- a/script/ios_build_functions.sh
+++ b/script/ios_build_functions.sh
@@ -9,7 +9,7 @@ function setup_build_environment ()
     # e.g. via brew. Xcode's Run Script phase doesn't seem to honor
     # ~/.MacOSX/environment.plist
     PATH="/usr/local/bin:/opt/boxen/homebrew/bin:$PATH"
-    
+
     pushd "$SCRIPT_DIR/.." > /dev/null
     ROOT_PATH="$PWD"
     popd > /dev/null
@@ -22,7 +22,7 @@ function setup_build_environment ()
     MACOSX_DEPLOYMENT_TARGET=""
 
     XCODE_MAJOR_VERSION=$(xcode_major_version)
-    
+
     CAN_BUILD_64BIT="0"
 
     # If IPHONEOS_DEPLOYMENT_TARGET has not been specified
@@ -32,7 +32,7 @@ function setup_build_environment ()
     then
         IPHONEOS_DEPLOYMENT_TARGET="6.0"
     fi
-    
+
     # Determine if we can be building 64-bit binaries
     if [ "${XCODE_MAJOR_VERSION}" -ge "5" ] && [ $(echo ${IPHONEOS_DEPLOYMENT_TARGET} '>=' 6.0 | bc -l) == "1" ]
     then
@@ -51,7 +51,7 @@ function setup_build_environment ()
 function build_all_archs ()
 {
     setup_build_environment
-    
+
     local setup=$1
     local build_arch=$2
     local finish_build=$3
@@ -80,8 +80,8 @@ function build_all_archs ()
         fi
 
         SDKNAME="${PLATFORM}${SDKVERSION}"
-        SDKROOT="$(ios_sdk_path ${SDKNAME})"
-        
+        SDKROOT="$(sdk_path ${SDKNAME})"
+
         echo "Building ${LIBRARY_NAME} for ${SDKNAME} ${ARCH}"
         echo "Please stand by..."
 
@@ -92,4 +92,3 @@ function build_all_archs ()
     # finish the build (usually lipo)
     eval $finish_build
 }
-

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -34,7 +34,10 @@ function setup_build_environment ()
     CAN_BUILD_ARM="0"
 
     # Determine if we can be building for ARM Macs
-    if [ "${XCODE_MAJOR_VERSION}" -ge "12" ] && [ "${XCODE_MINOR_VERSION}" -ge "2" ]
+    if [ "${XCODE_MAJOR_VERSION}" -ge "13" ]
+    then
+        CAN_BUILD_ARM="1"
+    elif  [ "${XCODE_MAJOR_VERSION}" -eq "12" ] && [ "${XCODE_MINOR_VERSION}" -ge "2" ]
     then
         CAN_BUILD_ARM="1"
     fi

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -62,14 +62,6 @@ function build_all_archs ()
     for ARCH in ${ARCHS}
     do
         PLATFORM="macos"
-        SDKVERSION=$(ios_sdk_version)
-
-        # if [ "${ARCH}" == "arm64" ]
-        # then
-        #     HOST="aarch64-apple-darwin"
-        # else
-        #     HOST="${ARCH}-apple-darwin"
-        # fi
 
         SDKNAME="${PLATFORM}${SDKVERSION}"
         SDKROOT="$(ios_sdk_path ${SDKNAME})"
@@ -107,12 +99,6 @@ function build_libgit2 ()
 
     pushd "build" > /dev/null
 
-    # LOL Cmake
-    #if [ "${ARCH}" != "i386" ] && [ "${ARCH}" != "x86_64" ]
-    #then
-        #SYS_ROOT="-DCMAKE_OSX_SYSROOT=${SDKROOT}"
-    #fi
-
     # install the each built arch somewhere sane
     INSTALL_PREFIX="${LIB_PATH}/${SDKNAME}-${ARCH}.sdk"
 
@@ -121,25 +107,12 @@ function build_libgit2 ()
     LOG="${INSTALL_PREFIX}/build-libgit2.log"
     echo "$LOG"
 
-
-    # cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
-    #     -DLIBSSH2_INCLUDE_DIRS:PATH=/usr/local/include/ \
-    #     -DBUILD_CLAR:BOOL=OFF \
-    #     -DTHREADSAFE:BOOL=ON \
-    #     ..
-    # cmake --build .
-
     cmake \
-        -DCMAKE_C_COMPILER_WORKS:BOOL=ON \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DCMAKE_PREFIX_PATH:PATH="${ROOT_PATH}/External/libssh2-mac/bin/${SDKNAME}-${ARCH}.sdk" \
-        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH:BOOL=ON \
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
         -DBUILD_CLAR:BOOL=OFF \
         -DTHREADSAFE:BOOL=ON \
-        -DCURL:BOOL=OFF \
-        -DCMAKE_C_FLAGS:STRING="-fembed-bitcode" \
-        "${SYS_ROOT}" \
         -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" \
         .. >> "${LOG}" 2>&1
     cmake --build . --target install >> "${LOG}" 2>&1
@@ -160,8 +133,6 @@ function fat_binary ()
     popd > /dev/null
 }
 
-
 build_all_archs setup build_libgit2 fat_binary
-
 
 echo "libgit2 has been updated."

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -108,7 +108,7 @@ function build_libgit2 ()
     LOG="${INSTALL_PREFIX}/build-libgit2.log"
     echo "$LOG"
 
-    cmake \
+    MACOSX_DEPLOYMENT_TARGET="10.9" cmake \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DCMAKE_PREFIX_PATH:PATH="${ROOT_PATH}/External/libssh2-mac/bin/${SDKNAME}-${ARCH}.sdk" \
         -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -61,10 +61,11 @@ function build_all_archs ()
 
     for ARCH in ${ARCHS}
     do
-        PLATFORM="macos"
+        PLATFORM="macosx"
+        SDKVERSION=$(macos_sdk_version)
 
         SDKNAME="${PLATFORM}${SDKVERSION}"
-        SDKROOT="$(ios_sdk_path ${SDKNAME})"
+        SDKROOT="$(sdk_path ${SDKNAME})"
 
         echo "Building ${LIBRARY_NAME} for ${SDKNAME} ${ARCH}"
         echo "Please stand by..."

--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -7,32 +7,161 @@ set -e
 # ~/.MacOSX/environment.plist
 PATH="/usr/local/bin:$PATH"
 
-if [ "External/libgit2.a" -nt "External/libgit2" ]
-then
-    echo "No update needed."
-    exit 0
-fi
+SCRIPT_DIR=$(dirname "$0")
+source "${SCRIPT_DIR}/xcode_functions.sh"
 
-cd "External/libgit2"
+function setup_build_environment ()
+{
+    # augment path to help it find cmake installed in /usr/local/bin,
+    # e.g. via brew. Xcode's Run Script phase doesn't seem to honor
+    # ~/.MacOSX/environment.plist
+    PATH="/usr/local/bin:$PATH"
 
-if [ -d "build" ]; then
+    pushd "$SCRIPT_DIR/.." > /dev/null
+    ROOT_PATH="$PWD"
+    popd > /dev/null
+
+    CLANG="/usr/bin/xcrun clang"
+    CC="${CLANG}"
+    CPP="${CLANG} -E"
+
+    # We need to clear this so that cmake doesn't have a conniption
+    MACOSX_DEPLOYMENT_TARGET=""
+
+    XCODE_MAJOR_VERSION=$(xcode_major_version)
+    XCODE_MINOR_VERSION=$(xcode_minor_version)
+
+    CAN_BUILD_ARM="0"
+
+    # Determine if we can be building for ARM Macs
+    if [ "${XCODE_MAJOR_VERSION}" -ge "12" ] && [ "${XCODE_MINOR_VERSION}" -ge "2" ]
+    then
+        CAN_BUILD_ARM="1"
+    fi
+
+    ARCHS="x86_64"
+    if [ "${CAN_BUILD_ARM}" -eq "1" ]
+    then
+        ARCHS="${ARCHS} arm64 arm64e"
+    fi
+}
+
+function build_all_archs ()
+{
+    setup_build_environment
+
+    local setup=$1
+    local build_arch=$2
+    local finish_build=$3
+
+    # run the prepare function
+    eval $setup
+
+    echo "Building for ${ARCHS}"
+
+    for ARCH in ${ARCHS}
+    do
+        PLATFORM="macos"
+        SDKVERSION=$(ios_sdk_version)
+
+        # if [ "${ARCH}" == "arm64" ]
+        # then
+        #     HOST="aarch64-apple-darwin"
+        # else
+        #     HOST="${ARCH}-apple-darwin"
+        # fi
+
+        SDKNAME="${PLATFORM}${SDKVERSION}"
+        SDKROOT="$(ios_sdk_path ${SDKNAME})"
+
+        echo "Building ${LIBRARY_NAME} for ${SDKNAME} ${ARCH}"
+        echo "Please stand by..."
+
+        # run the per arch build command
+        eval $build_arch
+    done
+
+    # finish the build (usually lipo)
+    eval $finish_build
+}
+
+function setup ()
+{
+    if [ "${ROOT_PATH}/External/libgit2-mac/libgit2-mac.a" -nt "${ROOT_PATH}/External/libgit2" ]
+    then
+        echo "No update needed."
+        exit 0
+    fi
+
+    LIBRARY_NAME="libgit2"
+    LIB_PATH="${ROOT_PATH}/External/libgit2-mac"
+    rm -rf "${LIB_PATH}"
+
+    pushd "${ROOT_PATH}/External/libgit2" > /dev/null
+}
+
+function build_libgit2 ()
+{
     rm -rf "build"
-fi
+    mkdir "build"
 
-mkdir build
-cd build
+    pushd "build" > /dev/null
 
-cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
-    -DLIBSSH2_INCLUDE_DIRS:PATH=/usr/local/include/ \
-    -DBUILD_CLAR:BOOL=OFF \
-    -DTHREADSAFE:BOOL=ON \
-    ..
-cmake --build .
+    # LOL Cmake
+    #if [ "${ARCH}" != "i386" ] && [ "${ARCH}" != "x86_64" ]
+    #then
+        #SYS_ROOT="-DCMAKE_OSX_SYSROOT=${SDKROOT}"
+    #fi
 
-product="libgit2.a"
-install_path="../../${product}"
-if [ "${product}" -nt "${install_path}" ]; then
-    cp -v "${product}" "${install_path}"
-fi
+    # install the each built arch somewhere sane
+    INSTALL_PREFIX="${LIB_PATH}/${SDKNAME}-${ARCH}.sdk"
+
+    mkdir -p "${INSTALL_PREFIX}"
+
+    LOG="${INSTALL_PREFIX}/build-libgit2.log"
+    echo "$LOG"
+
+
+    # cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
+    #     -DLIBSSH2_INCLUDE_DIRS:PATH=/usr/local/include/ \
+    #     -DBUILD_CLAR:BOOL=OFF \
+    #     -DTHREADSAFE:BOOL=ON \
+    #     ..
+    # cmake --build .
+
+    cmake \
+        -DCMAKE_C_COMPILER_WORKS:BOOL=ON \
+        -DBUILD_SHARED_LIBS:BOOL=OFF \
+        -DCMAKE_PREFIX_PATH:PATH="${ROOT_PATH}/External/libssh2-mac/bin/${SDKNAME}-${ARCH}.sdk" \
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH:BOOL=ON \
+        -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}/" \
+        -DBUILD_CLAR:BOOL=OFF \
+        -DTHREADSAFE:BOOL=ON \
+        -DCURL:BOOL=OFF \
+        -DCMAKE_C_FLAGS:STRING="-fembed-bitcode" \
+        "${SYS_ROOT}" \
+        -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" \
+        .. >> "${LOG}" 2>&1
+    cmake --build . --target install >> "${LOG}" 2>&1
+
+    # push the built library into the list
+    BUILT_LIB_PATHS+=("${INSTALL_PREFIX}/lib/libgit2.a")
+    popd > /dev/null
+}
+
+function fat_binary ()
+{
+    echo "Building fat binary..."
+
+    lipo -create "${BUILT_LIB_PATHS[@]}" -output "${ROOT_PATH}/External/libgit2-mac/libgit2-mac.a"
+
+    echo "Building done."
+
+    popd > /dev/null
+}
+
+
+build_all_archs setup build_libgit2 fat_binary
+
 
 echo "libgit2 has been updated."

--- a/script/xcode_functions.sh
+++ b/script/xcode_functions.sh
@@ -46,7 +46,7 @@ function macos_sdk_version ()
 }
 
 # Returns the path to the specified iOS SDK name
-function ios_sdk_path ()
+function sdk_path ()
 {
     /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -i $1 | grep 'Path:' | awk '{ print $2 }'
 }

--- a/script/xcode_functions.sh
+++ b/script/xcode_functions.sh
@@ -14,6 +14,11 @@ function xcode_major_version ()
     xcode_version | awk -F '.' '{ print $1 }'
 }
 
+function xcode_minor_version ()
+{
+    xcode_version | awk -F '.' '{ print $2 }'
+}
+
 # Returns the latest iOS SDK version available via xcodebuild.
 function ios_sdk_version ()
 {
@@ -26,7 +31,7 @@ function ios_sdk_version ()
     #   iPhoneSimulator9.0.sdk - Simulator - iOS 9.0 (iphonesimulator9.0)
     #   SDKVersion: 9.0
 
-    /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^iPhone' | tail -n 1 |  awk '{ print $2 }' 
+    /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^iPhone' | tail -n 1 |  awk '{ print $2 }'
 }
 
 # Returns the path to the specified iOS SDK name

--- a/script/xcode_functions.sh
+++ b/script/xcode_functions.sh
@@ -34,6 +34,17 @@ function ios_sdk_version ()
     /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^iPhone' | tail -n 1 |  awk '{ print $2 }'
 }
 
+function macos_sdk_version ()
+{
+    # The grep command produces output like the following, singling out the
+    # SDKVersion of just the Mac SDKs:
+    #
+    #     MacOSX11.0.sdk - macOS 11.0 (macosx11.0)
+    #     SDKVersion: 11.0
+    #     ...
+    /usr/bin/xcodebuild -version -sdk 2> /dev/null | grep -A 1 '^MacOSX' | tail -n 1 |  awk '{ print $2 }'
+}
+
 # Returns the path to the specified iOS SDK name
 function ios_sdk_path ()
 {


### PR DESCRIPTION
This fixes compilation for Mac targets using Carthage. I would rather we use https://github.com/light-tech/LibGit2-On-iOS/issues/1 and XCFrameworks eventually, but this works in my projects so far.